### PR TITLE
change endpoints for key and name

### DIFF
--- a/.github/workflows/test_build_app.yml
+++ b/.github/workflows/test_build_app.yml
@@ -4,8 +4,8 @@ on:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
     branches: [ main ]
-  pull_request:
-    branches: [ main ]
+  #pull_request:
+    #branches: [ main ]
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/test_build_app.yml
+++ b/.github/workflows/test_build_app.yml
@@ -4,8 +4,8 @@ on:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
     branches: [ main ]
-  #pull_request:
-    #branches: [ main ]
+  pull_request:
+    branches: [ main ]
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/readme.rst
+++ b/readme.rst
@@ -30,7 +30,7 @@ OMERO Search Engine
 
 * It is possible to query the search engine to get all the available resources (e.g. image) and their keys (names) using the following URL:
 
-    * 127.0.0.01:5556/api/v1/resources/all/getannotationkeys
+    * 127.0.0.01:5556/api/v1/resources/all/keys
 
 * The user can get the available values for a specific key for a recourse, e.g. what are the available values for Organism:
 

--- a/search_engine/api/v1/resources/resourse_analyser.py
+++ b/search_engine/api/v1/resources/resourse_analyser.py
@@ -112,7 +112,7 @@ def search_value_for_resource_(table_, value):
                 returned_results.append((singe_row))
                 key = buc.get("key")
                 key_no = buc.get("doc_count")
-                singe_row["Attribute"]=key
+                singe_row["key"]=key
                 singe_row["Value"] =value
                 singe_row["Number of %ss"%table_] =key_no
                 total_number+=key_no
@@ -159,7 +159,7 @@ def get_all_values_for_a_key(table_, key):
                 total_number += value_no
                 singe_row = {}
                 returned_results.append(singe_row)
-                singe_row["Attribute"] = key
+                singe_row["key"] = key
                 singe_row["Value"] = value
                 singe_row["Number of %ss" % table_] = value_no
 
@@ -189,7 +189,7 @@ def get_values_for_a_key(table_, key):
             total_number+=value_no
             singe_row = {}
             returned_results.append(singe_row)
-            singe_row["Attribute"] = key
+            singe_row["key"] = key
             singe_row["Value"] = value
             singe_row["Number of %ss"%table_] = value_no
     return {"data":returned_results, "total_number":total_number, "total_number_of_%s"%(table_):number_of_images,"total_number_of_buckets": number_of_buckets}
@@ -206,7 +206,7 @@ def prepare_search_results(results):
         row={}
         returned_results.append(row)
         res=hit["_source"]
-        row["Attribute"] = res["Attribute"]
+        row["key"] = res["Attribute"]
         row["Value"] = res["Value"]
         resource=res.get("resource")
         row["Number of %ss" % resource] = res.get("items_in_the_bucket")
@@ -228,7 +228,7 @@ def prepare_search_results_buckets(results_):
             row={}
             returned_results.append(row)
             res=hit["_source"]
-            row["Attribute"] = res["Attribute"]
+            row["key"] = res["Attribute"]
             row["Value"] = res["Value"]
             resource=res.get("resource")
             row["Number of %ss" % resource] = res.get("items_in_the_bucket")
@@ -338,7 +338,6 @@ key_values_buckets_template_2= Template ('''{"query":{"bool":{"must":[{"bool":{"
 def connect_elasticsearch(es_index, query, count=False):
     es = search_omero_app.config.get("es_connector")
     #test the elasticsearch connection
-    print (es)
     if not es.ping():
         raise ValueError("Elasticsearch connection failed")
     if not count:

--- a/search_engine/api/v1/resources/resourse_analyser.py
+++ b/search_engine/api/v1/resources/resourse_analyser.py
@@ -112,7 +112,7 @@ def search_value_for_resource_(table_, value):
                 returned_results.append((singe_row))
                 key = buc.get("key")
                 key_no = buc.get("doc_count")
-                singe_row["key"]=key
+                singe_row["Key"]=key
                 singe_row["Value"] =value
                 singe_row["Number of %ss"%table_] =key_no
                 total_number+=key_no
@@ -159,7 +159,7 @@ def get_all_values_for_a_key(table_, key):
                 total_number += value_no
                 singe_row = {}
                 returned_results.append(singe_row)
-                singe_row["key"] = key
+                singe_row["Key"] = key
                 singe_row["Value"] = value
                 singe_row["Number of %ss" % table_] = value_no
 
@@ -189,7 +189,7 @@ def get_values_for_a_key(table_, key):
             total_number+=value_no
             singe_row = {}
             returned_results.append(singe_row)
-            singe_row["key"] = key
+            singe_row["Key"] = key
             singe_row["Value"] = value
             singe_row["Number of %ss"%table_] = value_no
     return {"data":returned_results, "total_number":total_number, "total_number_of_%s"%(table_):number_of_images,"total_number_of_buckets": number_of_buckets}
@@ -206,7 +206,7 @@ def prepare_search_results(results):
         row={}
         returned_results.append(row)
         res=hit["_source"]
-        row["key"] = res["Attribute"]
+        row["Key"] = res["Attribute"]
         row["Value"] = res["Value"]
         resource=res.get("resource")
         row["Number of %ss" % resource] = res.get("items_in_the_bucket")
@@ -228,7 +228,7 @@ def prepare_search_results_buckets(results_):
             row={}
             returned_results.append(row)
             res=hit["_source"]
-            row["key"] = res["Attribute"]
+            row["Key"] = res["Attribute"]
             row["Value"] = res["Value"]
             resource=res.get("resource")
             row["Number of %ss" % resource] = res.get("items_in_the_bucket")

--- a/search_engine/api/v1/resources/swagger_docs/getannotationkeys.yml
+++ b/search_engine/api/v1/resources/swagger_docs/getannotationkeys.yml
@@ -1,7 +1,7 @@
-Get all the available attributes for resource or all resources.
+Get all the available keys (attributes) for resource or all resources.
 ---
 tags:
- -  Available attributes for a resource
+ -  Available keys (attributes) for a resource
 parameters:
   - name: resource_table
     in: path

--- a/search_engine/api/v1/resources/swagger_docs/getannotationvalueskey.yml
+++ b/search_engine/api/v1/resources/swagger_docs/getannotationvalueskey.yml
@@ -1,7 +1,7 @@
-Get the available values for a resource attribute, for example, it can return the available values for the "Cell Line" attribute for "image".
+Get the available values for a resource n key (attribute), for example, it can return the available values for the "Cell Line" attribute for "image".
 ---
 tags:
- - Available values for a resource attribute
+ - Available values for a resource key (attribute)
 parameters:
   - name: resource_table
     in: path

--- a/search_engine/api/v1/resources/swagger_docs/searchvaluesusingkey.yml
+++ b/search_engine/api/v1/resources/swagger_docs/searchvaluesusingkey.yml
@@ -1,7 +1,7 @@
 Get the available values for an attribute for one or all resources.
  ---
 tags:
- -  Available values for a resourse attribute
+ -  Available values for a resourse key (attribute)
 parameters:
   - name: resource_table
     in: path

--- a/search_engine/api/v1/resources/urls.py
+++ b/search_engine/api/v1/resources/urls.py
@@ -109,8 +109,8 @@ def search_values_for_a_key(resource_table):
     if not key:
         return jsonify(build_error_message("No key is provided "))
     return jsonify(query_cashed_bucket (key, resource_table))
-
-@resources.route('/<resource_table>/getannotationkeys/',methods=['GET'])
+#getannotationkeys==> keys
+@resources.route('/<resource_table>/keys/',methods=['GET'])
 def get_resource_keys(resource_table):
     """
     file: swagger_docs/getannotationkeys.yml
@@ -137,8 +137,8 @@ def get_resource_key_value(resource_table):
         return jsonify (build_error_message("No key is provided"))
     return jsonify(get_resource_attribute_values(resource_table, key))
 
-
-@resources.route('/<resource_table>/getresourcenames/',methods=['GET'])
+#getresourcenames==>names
+@resources.route('/<resource_table>/names/',methods=['GET'])
 def get_resource_names_(resource_table):
     """
     file: swagger_docs/getresourcenames.yml


### PR DESCRIPTION
This PR includes the following  modifications for issue no. 4:
- Changing endpoints  `getannotationkeys` to `keys` and `getresourcenames` to `names.`
- Changing   `Attribute` to Key.

This PR does not include applying the `case_sensitive` flag to include the `key` as I will create a separate PR to implement this.