### PR TITLE
Return containers only

### DIFF
--- a/examples/return_containers_only.py
+++ b/examples/return_containers_only.py
@@ -1,0 +1,33 @@
+import logging
+import requests
+import json
+# url to send the query
+image_search = "/resources/image/search/"
+# search engine url
+base_url = "http://127.0.0.1:5577/api/v1/"
+#base_url ="https://idr-testing.openmicroscopy.org/searchengineapi/api/v1/"
+import sys
+logging.basicConfig(stream=sys.stdout, level=logging.INFO)
+'''
+It is required to search the database for:
+"Organism"="Homo sapiens" 
+and return the containers only, the studies which conatins the results
+As it is a simple search, a single clause then search can be used to simplfy the request
+http://127.0.0.1:5577/api/v1/resources/image/search/?key=cell%20line&value=hela&return_containers=true
+
+curl -X GET "http://127.0.0.1:5577/api/v1/resources/image/search/?key=Organism&value=Homo%20sapiens&return_containers=true"
+'''
+recieved_results=[]
+page=0
+ids=[]
+logging.info(" Searching for:  OrganismHomo sapiens")
+
+
+url="%s%s?key=Organism&value=Homo sapiens&return_containers=true"%(base_url,image_search)
+resp = requests.get(url)
+returned_results = json.loads(resp.text)
+if returned_results.get("results"):
+    if len(returned_results.get("results").get("results"))==0:
+        logging.info ("No results is found")
+    for item in returned_results.get("results").get("results"):
+        logging.info ("Study: %s"%item.get("Name (IDR number)"))

--- a/examples/return_studies.py
+++ b/examples/return_studies.py
@@ -1,0 +1,63 @@
+import logging
+import requests
+import json
+# url to send the query
+# search engine url
+submit_query_url = "http://127.0.0.1:5577/api/v1/resources/submitquery_returnstudies/"
+
+#base_url ="https://idr-testing.openmicroscopy.org/searchengineapi/api/v1/"
+import sys
+logging.basicConfig(stream=sys.stdout, level=logging.INFO)
+'''
+The following query will answer this question:
+Get a list of studies which satsidy the following conditions:
+"Organism"="mus musculus" 
+ and 
+"Imaging Method"="light sheet fluorescence microscopy, spim"
+'''
+recieved_results=[]
+
+logging.info("Get a study list for:  (Organism= mus musculus) and (Imaging Method=light sheet fluorescence microscopy, spim)")
+
+'''
+url="%s%s?key=Organism&value=Homo sapiens&return_containers=true"%(base_url,image_search)
+resp = requests.get(url)
+returned_results = json.loads(resp.text)
+if returned_results.get("results"):
+    if len(returned_results.get("results").get("results"))==0:
+        logging.info ("No results is found")
+    for item in returned_results.get("results").get("results"):
+        logging.info ("Study: %s"%item.get("Name (IDR number)"))
+'''
+
+data={
+   "resource":"image",
+   "query_details":{
+      "and_filters":[
+         {
+            "name":"Organism",
+            "value":"mus musculus",
+            "operator":"equals",
+            "resource":"image"
+         },
+         {
+            "name":"Imaging Method",
+            "value":"light sheet fluorescence microscopy, spim",
+            "operator":"equals",
+            "resource":"project"
+         }
+      ],
+      "or_filters":[
+
+      ],
+      "case_sensitive":False
+   }
+}
+
+resp = requests.post(submit_query_url, data=json.dumps(data))
+returned_results = json.loads(resp.text)
+if returned_results.get("results"):
+    if len(returned_results.get("results").get("results"))==0:
+        logging.info ("No results is found")
+    for item in returned_results.get("results").get("results"):
+        logging.info ("Study: %s"%item.get("Name (IDR number)"))

--- a/omero_search_engine/api/v1/resources/query_handler.py
+++ b/omero_search_engine/api/v1/resources/query_handler.py
@@ -1,5 +1,6 @@
 from omero_search_engine import search_omero_app
 from  omero_search_engine.api.v1.resources.urls import search_resource_annotation, get_resource_names
+from  omero_search_engine.api.v1.resources.utils import search_resource_annotation_return_conatines_only
 import json
 from jsonschema import validate, ValidationError, SchemaError, RefResolver
 from os.path import abspath,dirname
@@ -127,7 +128,7 @@ class QueryRunner(object, ):
         self.image_query={}
         self.additional_image_conds=[]
         self.return_columns=return_columns
-        self.return_containers=self.return_containers
+        self.return_containers=return_containers
 
     def get_iameg_non_image_query(self):
         has_main=False
@@ -302,14 +303,11 @@ def seracrh_query(query,resource,bookmark,raw_elasticsearch_query, main_attribut
             q_data["bookmark"] =bookmark
             q_data["raw_elasticsearch_query"] = raw_elasticsearch_query
             ress=search_resource_annotation(resource, q_data.get("query"), raw_elasticsearch_query=raw_elasticsearch_query,
-                                       page=query.get("page"), bookmark=bookmark)
+                                       page=query.get("page"), bookmark=bookmark,return_containers=return_containers)
         else:
-            if not return_containers:
-                ress=search_resource_annotation(resource, q_data.get("query"))
-            else:
-                ###Should have a method to search the elasticsearch and returns the containers only,
-                #It is hard coddedno in the util search_annotation  method.
-                ress = search_resource_annotation_retuen_conatines_only(resource, q_data.get("query"))
+            ###Should have a method to search the elasticsearch and returns the containers only,
+            #It is hard coddedno in the util search_annotation  method.
+            ress = search_resource_annotation(resource, q_data.get("query"),return_containers=return_containers)
         ress["Error"] = "none"
         return ress
     except Exception as ex:

--- a/omero_search_engine/api/v1/resources/query_handler.py
+++ b/omero_search_engine/api/v1/resources/query_handler.py
@@ -490,7 +490,7 @@ def determine_search_results_(query_, return_columns=False, return_containers=Fa
     return query_results
 
 
-def simple_search(key, value, operator,  case_sensitive, bookmark, resource, study):
+def simple_search(key, value, operator,  case_sensitive, bookmark, resource, study, return_containers=False):
     if not operator:
         operator='equals'
     and_filters=[{"name": key, "value": value, "operator": operator, "resource":resource }]
@@ -500,7 +500,7 @@ def simple_search(key, value, operator,  case_sensitive, bookmark, resource, stu
     query_details["bookmark"]=[bookmark]
     query_details["case_sensitive"]=case_sensitive
     if not study:
-        return (search_resource_annotation(resource, {"query_details": query_details},bookmark=bookmark))
+        return (search_resource_annotation(resource, {"query_details": query_details},bookmark=bookmark, return_containers=return_containers))
     else:
         and_filters.append({"name": "Name (IDR number)", "value": study, "operator": "equals", "resource":"project"})
         return determine_search_results_({"query_details": query_details})

--- a/omero_search_engine/api/v1/resources/query_handler.py
+++ b/omero_search_engine/api/v1/resources/query_handler.py
@@ -275,9 +275,13 @@ class QueryRunner(object, ):
         else:
             bookmark=None
 
-        res=seracrh_query(query, resource, bookmark, self.raw_elasticsearch_query, main_attributes,return_containers=self.return_containers)
+        #res=seracrh_query(query, resource, bookmark, self.raw_elasticsearch_query, main_attributes,return_containers=self.return_containers)
         if resource=="image" and self.return_containers:
-            pass
+            res = seracrh_query(query, resource, bookmark, self.raw_elasticsearch_query, main_attributes,
+                                return_containers=self.return_containers)
+        else:
+            res = seracrh_query(query, resource, bookmark, self.raw_elasticsearch_query, main_attributes)
+
         if resource != "image":
             return res
         elif self.return_columns:

--- a/omero_search_engine/api/v1/resources/swagger_docs/search.yml
+++ b/omero_search_engine/api/v1/resources/swagger_docs/search.yml
@@ -37,6 +37,10 @@ parameters:
     description: bookmark is used to the call the next page if number of results is bigger than 1000, it returns with each reasult page.
     in: query
     type: integer
+  - name: return_containers
+    in: query
+    type: boolean
+    required: false
 responses:
   200:
     description: A JSON contains the search results

--- a/omero_search_engine/api/v1/resources/swagger_docs/searchannotation.yml
+++ b/omero_search_engine/api/v1/resources/swagger_docs/searchannotation.yml
@@ -36,6 +36,10 @@ parameters:
   - name: data
     in: body
     required: true
+  - name: return_containers
+    in: query
+    type: boolean
+    required: false
    # required:
    #   - and_filter
    #   - or_filter

--- a/omero_search_engine/api/v1/resources/swagger_docs/submitquery_returncontainers.yml
+++ b/omero_search_engine/api/v1/resources/swagger_docs/submitquery_returncontainers.yml
@@ -1,0 +1,63 @@
+A searchengine endpoint to accept complex query but it will return the continers only (Name (Idr number))
+API endpoint to search the annotation (key/value pair), the main difference between this endpoint and searchannotation is this one can be used to search different resources and return the images which satisfy the search conditions.
+The query data has a similar format to the query for searchannotation.
+Example:
+  
+  {
+     "resource":"image",
+     "query_details":{
+        "and_filters":[
+           {
+              "name":"Cell Line",
+              "operator":"equals",
+              "query_type":"keyvalue",
+              "resource":"image",
+              "value":"hela"
+           }
+        ],
+        "case_sensitive":false,
+        "or_filters":[
+
+        ]
+     }
+
+
+  }
+---
+tags:
+ - Mixed Complex query
+
+parameters:
+  - name: return_columns
+    description: return additional columns to help display the results in a table
+    in: query
+    type: boolean
+    required: false
+  - name: data
+    in: body
+    required: true
+    #examples:
+    #  query: {
+    #    "resource": "image",
+    #    "query_details": {
+    #      "and_filters": [
+    #        {
+    #          "name": "Gene Symbol",
+    #          "value": "pdx1",
+    #          "operator": "equals",
+    #          "resource": "image"
+    #        }
+    #      ],
+    #      "or_filters": [#
+
+    #      ],
+    #      "case_sensitive": false
+    #    },
+    #    "mode": "usesearchterms"
+    #  }
+
+responses:
+  200:
+    description: A JSON contains the results
+    examples:
+      results: []

--- a/omero_search_engine/api/v1/resources/swagger_docs/submitquery_returncontainers.yml
+++ b/omero_search_engine/api/v1/resources/swagger_docs/submitquery_returncontainers.yml
@@ -2,11 +2,11 @@ A searchengine endpoint to accept complex query but it will return the continers
 API endpoint to search the annotation (key/value pair), the main difference between this endpoint and searchannotation is this one can be used to search different resources and return the images which satisfy the search conditions.
 The query data has a similar format to the query for searchannotation.
 Example:
-  
+
   {
      "resource":"image",
-     "query_details":{
-        "and_filters":[
+     "query_details": {
+        "and_filters": [
            {
               "name":"Cell Line",
               "operator":"equals",
@@ -15,14 +15,38 @@ Example:
               "value":"hela"
            }
         ],
-        "case_sensitive":false,
-        "or_filters":[
+        "case_sensitive": false,
+        "or_filters": [
 
         ]
      }
-
-
   }
+
+Another example:
+
+  {
+    "resource": "image",
+    "query_details": {
+      "and_filters": [
+        {
+          "name": "Organism",
+          "value": "mus musculus",
+          "operator": "equals",
+          "resource": "image"
+        },
+        {
+          "name": "Imaging Method",
+          "value": "light sheet fluorescence microscopy, spim",
+          "operator": "equals",
+          "resource": "project"
+        }
+      ],
+      "or_filters": [
+      ],
+      "case_sensitive": false
+    }
+  }
+
 ---
 tags:
  - Mixed Complex query
@@ -37,24 +61,8 @@ parameters:
     in: body
     required: true
     #examples:
-    #  query: {
-    #    "resource": "image",
-    #    "query_details": {
-    #      "and_filters": [
-    #        {
-    #          "name": "Gene Symbol",
-    #          "value": "pdx1",
-    #          "operator": "equals",
-    #          "resource": "image"
-    #        }
-    #      ],
-    #      "or_filters": [#
 
-    #      ],
-    #      "case_sensitive": false
-    #    },
-    #    "mode": "usesearchterms"
-    #  }
+
 
 responses:
   200:

--- a/omero_search_engine/api/v1/resources/urls.py
+++ b/omero_search_engine/api/v1/resources/urls.py
@@ -33,6 +33,9 @@ def search_resource_page(resource_table):
             bookmark=data.get("bookmark")
             raw_elasticsearch_query=data.get("raw_elasticsearch_query")
             return_containers = data.get("return_containers")
+            if return_containers:
+                return_containers = json.loads(return_containers.lower())
+
             resource_list = search_resource_annotation(resource_table, query, raw_elasticsearch_query=raw_elasticsearch_query,page=page,bookmark=bookmark, return_containers=return_containers)
             return jsonify(resource_list)
         else:
@@ -81,12 +84,13 @@ def search_resource(resource_table):
     validation_results=query_validator(query)
     if validation_results=="OK":
         return_containers = request.args.get("return_containers")
+        if return_containers:
+            return_containers = json.loads(return_containers.lower())
+
         resource_list = search_resource_annotation(resource_table, query,return_containers=return_containers )
         return jsonify(resource_list)
     else:
         return jsonify(build_error_message(validation_results))
-
-
 
 @resources.route('/<resource_table>/searchvalues/',methods=['GET'])
 def get_values_using_value(resource_table):
@@ -217,5 +221,8 @@ def search(resource_table):
     operator=request.args.get("operator")
     bookmark=request.args.get("bookmark")
     from omero_search_engine.api.v1.resources.query_handler import simple_search
-    results=simple_search(key, value, operator,case_sensitive,bookmark, resource_table, study)
+    return_containers = request.args.get("return_containers")
+    if return_containers:
+        return_containers = json.loads(return_containers.lower())
+    results=simple_search(key, value, operator,case_sensitive,bookmark, resource_table, study, return_containers)
     return jsonify(results)

--- a/omero_search_engine/api/v1/resources/urls.py
+++ b/omero_search_engine/api/v1/resources/urls.py
@@ -163,7 +163,7 @@ def get_resource_names_(resource_table):
     return jsonify (names)
 
 
-@resources.route('/submitquery_returncontainers/',methods=['POST'])
+@resources.route('/submitquery_returnstudies/',methods=['POST'])
 def submit_query_return_containers():
     """
     file: swagger_docs/submitquery_returncontainers.yml

--- a/omero_search_engine/api/v1/resources/urls.py
+++ b/omero_search_engine/api/v1/resources/urls.py
@@ -157,6 +157,29 @@ def get_resource_names_(resource_table):
     return jsonify (names)
 
 
+@resources.route('/submitquery_returnstudies/',methods=['POST'])
+def submit_query_return_containers():
+    """
+    file: swagger_docs/submitquery.yml
+    """
+    try:
+        query =json.loads(request.data)
+    except:
+        query=None
+    if not query:
+        return jsonify(build_error_message("No query is provided"))
+    return_columns=request.args.get("return_columns")
+    if return_columns:
+        try:
+            return_columns=json.loads(return_columns.lower())
+        except:
+            return_columns =False
+    validation_results=query_validator(query)
+    if validation_results=="OK":
+        return jsonify(determine_search_results_(query, return_columns, True))
+    else:
+        return jsonify(build_error_message(validation_results))
+
 @resources.route('/submitquery/',methods=['POST'])
 def submit_query():
     """

--- a/omero_search_engine/api/v1/resources/urls.py
+++ b/omero_search_engine/api/v1/resources/urls.py
@@ -32,7 +32,8 @@ def search_resource_page(resource_table):
             page=data.get("page")
             bookmark=data.get("bookmark")
             raw_elasticsearch_query=data.get("raw_elasticsearch_query")
-            resource_list = search_resource_annotation(resource_table, query, raw_elasticsearch_query=raw_elasticsearch_query,page=page,bookmark=bookmark)
+            return_containers = data.get("return_containers")
+            resource_list = search_resource_annotation(resource_table, query, raw_elasticsearch_query=raw_elasticsearch_query,page=page,bookmark=bookmark, return_containers=return_containers)
             return jsonify(resource_list)
         else:
             return jsonify(build_error_message(validation_results))
@@ -79,7 +80,8 @@ def search_resource(resource_table):
         #check if the app configuration will use ASYNCHRONOUS SEARCH or not.
     validation_results=query_validator(query)
     if validation_results=="OK":
-        resource_list = search_resource_annotation(resource_table, query)
+        return_containers = request.args.get("return_containers")
+        resource_list = search_resource_annotation(resource_table, query,return_containers=return_containers )
         return jsonify(resource_list)
     else:
         return jsonify(build_error_message(validation_results))

--- a/omero_search_engine/api/v1/resources/urls.py
+++ b/omero_search_engine/api/v1/resources/urls.py
@@ -163,10 +163,10 @@ def get_resource_names_(resource_table):
     return jsonify (names)
 
 
-@resources.route('/submitquery_returnstudies/',methods=['POST'])
+@resources.route('/submitquery_returncontainers/',methods=['POST'])
 def submit_query_return_containers():
     """
-    file: swagger_docs/submitquery.yml
+    file: swagger_docs/submitquery_returncontainers.yml
     """
     try:
         query =json.loads(request.data)
@@ -182,7 +182,7 @@ def submit_query_return_containers():
             return_columns =False
     validation_results=query_validator(query)
     if validation_results=="OK":
-        return jsonify(determine_search_results_(query, return_columns, True))
+        return jsonify(determine_search_results_(query, return_columns, return_containers=True))
     else:
         return jsonify(build_error_message(validation_results))
 

--- a/omero_search_engine/api/v1/resources/utils.py
+++ b/omero_search_engine/api/v1/resources/utils.py
@@ -530,7 +530,26 @@ def search_resource_annotation(table_, query, raw_elasticsearch_query=None, page
             query["_source"]= {
                 "includes": ["screen_name","project_name" ]
             }
-        res=search_index_using_search_after(res_index, query, page, bookmark, return_containers)
+            res = search_index_using_search_after(res_index, query, page, bookmark, return_containers)
+            query["collapse"] = {
+                "field": "screen_name.keyvalue"
+            }
+            res_2 = search_index_using_search_after(res_index, query, page, bookmark, return_containers)
+            studies=[]
+            if len(res)>0:
+                for item1 in res.get("results"):
+                    pr=item1.get("project_name")
+                    if pr and pr not in studies:
+                        studies.append({"Name (IDR number)": pr})
+            if len(res_2) > 0:
+                for item2 in res_2.get("results"):
+                    sc = item2.get("screen_name")
+                    if sc and sc not in studies:
+                        studies.append({"Name (IDR number)": sc})
+            res={"results": studies}
+
+        else:
+            res=search_index_using_search_after(res_index, query, page, bookmark, return_containers)
         notice=""
         end_time = time.time()
         query_time = ("%.2f" % (end_time - start_time))

--- a/omero_search_engine/api/v1/resources/utils.py
+++ b/omero_search_engine/api/v1/resources/utils.py
@@ -428,11 +428,11 @@ def search_index_using_search_after(e_index, query, page, bookmark_):
     returned_results = []
     if not page:
         page = 1
-    page_size = search_omero_app.config.get("PAGE_SIZE")
+    page_size =search_omero_app.config.get("PAGE_SIZE")
     es = search_omero_app.config.get("es_connector")
     start__ = datetime.now()
-    res = es.count(index=e_index, body=query)
-    size = res['count']
+    #res = es.count(index=e_index, body=query)
+    size = 1#res['count']
     search_omero_app.logger.info("Total: %s" % size)
     query['size'] = page_size
     if size % page_size == 0:
@@ -466,7 +466,10 @@ def search_index_using_search_after(e_index, query, page, bookmark_):
         bookmark = [res['hits']['hits'][-1]['sort'][0]]
         page += 1
     return {"results": returned_results, "total_pages": no_of_pages, "bookmark": bookmark, "size": size, "page": page}
-    
+
+def search_resource_annotation_return_conatines_only(table_, query, raw_elasticsearch_query=None, page=None,bookmark=None):
+
+    pass
 def search_resource_annotation(table_, query, raw_elasticsearch_query=None, page=None,bookmark=None):
     '''
     @table_: the resource table, e.g. image. project, etc.
@@ -508,6 +511,13 @@ def search_resource_annotation(table_, query, raw_elasticsearch_query=None, page
         else:
             query=raw_elasticsearch_query
             raw_query_to_send_back=copy.copy(raw_elasticsearch_query)
+        #code to return the containers only, needs to be alrted to diffemtiate between this and retrun the results, may be new method
+        query["collapse"]= {
+            "field": "project_name.keyvalue"
+        }
+        query["_source"]= {
+            "includes": ["screen_name","project_name" ]
+        }
         res=search_index_using_search_after(res_index, query, page, bookmark)
         notice=""
         end_time = time.time()

--- a/omero_search_engine/api/v1/resources/utils.py
+++ b/omero_search_engine/api/v1/resources/utils.py
@@ -523,7 +523,8 @@ def search_resource_annotation(table_, query, raw_elasticsearch_query=None, page
             query=raw_elasticsearch_query
             raw_query_to_send_back=copy.copy(raw_elasticsearch_query)
         if return_containers:
-            #code to return the containers only, needs to be alrted to diffentiate between this and retrun the results, may be a new method
+            #code to return the containers only
+            # It will call the projects container first then search within screens
             query["collapse"]= {
                 "field": "project_name.keyvalue"
             }
@@ -535,6 +536,7 @@ def search_resource_annotation(table_, query, raw_elasticsearch_query=None, page
                 "field": "screen_name.keyvalue"
             }
             res_2 = search_index_using_search_after(res_index, query, page, bookmark, return_containers)
+            #Combines the containers reults
             studies=[]
             if len(res)>0:
                 for item1 in res.get("results"):


### PR DESCRIPTION
Sometimes it is needed to return the containers (project or screen) rather than the images for search results.
This pull request adds the support to return the containers only. 
The user can use a dedicated API endpoint 
`/submitquery_returnstudies/`.

Also, if the user adds `return_containers=true`  to the  `/search/`  or  `/searchannotation/` endpoints, it will return the containers only.

It can be used to answer a question like that:
Get a list of studies which satisfy the following conditions:
"Organism"="mus musculus" 
and 
"Imaging Method"="light sheet fluorescence microscopy, spim"

The query should have the same format 