### PR TITLE
Generate a csv file for attribute buckets

### DIFF
--- a/omero_search_engine/api/v1/resources/resourse_analyser.py
+++ b/omero_search_engine/api/v1/resources/resourse_analyser.py
@@ -238,6 +238,24 @@ def prepare_search_results_buckets(results_):
     return {"data": returned_results, "total_number": total_number,
             "total_number_of_%s" % (resource): total, "total_number_of_buckets": number_of_buckets, "total_items":total_items}
 
+
+def get_key_values_return_contents(name ,resource,csv):
+    from flask import jsonify, Response
+    resource_keys = query_cashed_bucket(name, resource)
+    #if a csv flag is true thenm iut will send a scv file which contains the results
+    d = resource_keys.get("data")
+    key_string = ','.join(d[0].keys())
+    st = ''
+    for e in d:
+        st = st + '\n' + ','.join(str(sr) for sr in e.values())
+    content = key_string + st
+    return Response(
+        content,
+        mimetype="text/csv",
+        headers={"Content-disposition":
+                     "attachment; filename=%s.csv" % name})
+    return jsonify(resource_keys)
+
 def query_cashed_bucket(name ,resource, es_index="key_value_buckets_information"):
     #returns possible matches for a specific resource
     if resource !="all":

--- a/omero_search_engine/api/v1/resources/resourse_analyser.py
+++ b/omero_search_engine/api/v1/resources/resourse_analyser.py
@@ -243,18 +243,34 @@ def get_key_values_return_contents(name ,resource,csv):
     from flask import jsonify, Response
     resource_keys = query_cashed_bucket(name, resource)
     #if a csv flag is true thenm iut will send a scv file which contains the results
+    #otherwise it will return a json 
     if csv:
-        d = resource_keys.get("data")
-        key_string = ','.join(d[0].keys())
-        st = ''
-        for e in d:
-            st = st + '\n' + ','.join(str(sr) for sr in e.values())
-        content = key_string + st
+        if resource != 'all':
+            d = resource_keys.get("data")
+            print (d)
+            key_string = ','.join(d[0].keys())
+            st = ''
+            for e in d:
+                st = st + '\n' + ','.join(str(sr) for sr in e.values())
+            content = key_string + st
+
+        else:
+            key_string=''
+            content=[]
+            for resource_, data in resource_keys.items():
+                d = data.get("data")
+                if not key_string:
+                    key_string ="resourse,"+ ','.join(d[0].keys())
+                for e in d:
+                    content.append(resource_ +", "+','.join(str(sr) for sr in e.values()))
+
+            content = key_string +'\n'+ '\n'.join(content)
         return Response(
             content,
             mimetype="text/csv",
             headers={"Content-disposition":
-                         "attachment; filename=%s.csv" % name})
+                         "attachment; filename=%s_%s.csv" % (name,resource)})
+
     return jsonify(resource_keys)
 
 def query_cashed_bucket(name ,resource, es_index="key_value_buckets_information"):

--- a/omero_search_engine/api/v1/resources/resourse_analyser.py
+++ b/omero_search_engine/api/v1/resources/resourse_analyser.py
@@ -243,17 +243,18 @@ def get_key_values_return_contents(name ,resource,csv):
     from flask import jsonify, Response
     resource_keys = query_cashed_bucket(name, resource)
     #if a csv flag is true thenm iut will send a scv file which contains the results
-    d = resource_keys.get("data")
-    key_string = ','.join(d[0].keys())
-    st = ''
-    for e in d:
-        st = st + '\n' + ','.join(str(sr) for sr in e.values())
-    content = key_string + st
-    return Response(
-        content,
-        mimetype="text/csv",
-        headers={"Content-disposition":
-                     "attachment; filename=%s.csv" % name})
+    if csv:
+        d = resource_keys.get("data")
+        key_string = ','.join(d[0].keys())
+        st = ''
+        for e in d:
+            st = st + '\n' + ','.join(str(sr) for sr in e.values())
+        content = key_string + st
+        return Response(
+            content,
+            mimetype="text/csv",
+            headers={"Content-disposition":
+                         "attachment; filename=%s.csv" % name})
     return jsonify(resource_keys)
 
 def query_cashed_bucket(name ,resource, es_index="key_value_buckets_information"):

--- a/omero_search_engine/api/v1/resources/resourse_analyser.py
+++ b/omero_search_engine/api/v1/resources/resourse_analyser.py
@@ -243,38 +243,44 @@ def get_key_values_return_contents(name ,resource,csv):
     from flask import jsonify, Response
     resource_keys = query_cashed_bucket(name, resource)
     #if a csv flag is true thenm iut will send a scv file which contains the results
-    #otherwise it will return a json 
+    #otherwise it will return a json
     if csv:
         if resource != 'all':
+            content=''
             d = resource_keys.get("data")
-            print (d)
-            key_string = ','.join(d[0].keys())
-            st = ''
-            for e in d:
-                st = st + '\n' + ','.join(str(sr) for sr in e.values())
-            content = key_string + st
+            if d and len (d)>0:
+                key_string = ','.join(d[0].keys())
+                st = ''
+                for e in d:
+                    st = st + '\n" %s"'%('","'.join(str(sr) for sr in e.values()))
+                content = key_string + st
 
         else:
             key_string=''
             content=[]
             for resource_, data in resource_keys.items():
                 d = data.get("data")
-                if not key_string:
-                    key_string ="resourse,"+ ','.join(d[0].keys())
-                for e in d:
-                    content.append(resource_ +", "+','.join(str(sr) for sr in e.values()))
+                if d and len(d)>0:
+                    if not key_string:
+                        key_string ="resourse,"+ ','.join(d[0].keys())
+                    for e in d:
+                        content.append('%s,'%resource_+'"%s"'%(('","'.join(str(sr) for sr in e.values()))))
+
 
             content = key_string +'\n'+ '\n'.join(content)
-        return Response(
-            content,
-            mimetype="text/csv",
-            headers={"Content-disposition":
-                         "attachment; filename=%s_%s.csv" % (name,resource)})
+        if content and len(content)>0:
+            return Response(
+                content,
+                mimetype="text/csv",
+                headers={"Content-disposition":
+                             "attachment; filename=%s_%s.csv" % (name,resource)})
 
     return jsonify(resource_keys)
 
 def query_cashed_bucket(name ,resource, es_index="key_value_buckets_information"):
     #returns possible matches for a specific resource
+    if name:
+        name=name.strip()
     if resource !="all":
         query=key_values_buckets_template.substitute(name=name, resource=resource)
         res=search_index_for_values_get_all_buckets(es_index, query)

--- a/omero_search_engine/api/v1/resources/resourse_analyser.py
+++ b/omero_search_engine/api/v1/resources/resourse_analyser.py
@@ -273,7 +273,7 @@ def get_key_values_return_contents(name ,resource,csv):
                 content,
                 mimetype="text/csv",
                 headers={"Content-disposition":
-                             "attachment; filename=%s_%s.csv" % (name,resource)})
+                             "attachment; filename=%s_%s.csv" % (name.replace(' ','_'),resource)})
 
     return jsonify(resource_keys)
 

--- a/omero_search_engine/api/v1/resources/swagger_docs/searchvaluesusingkey.yml
+++ b/omero_search_engine/api/v1/resources/swagger_docs/searchvaluesusingkey.yml
@@ -1,4 +1,36 @@
 Get the available values for an attribute for one or all resources.
+This following is the most common attributes for each resource
+
+   project:
+      Imaging Method,
+      Publication Title,
+      Publication Authors,
+      Study Type,
+      License
+
+   screen:
+      Screen Technology Type,
+      Screen Type
+
+   image:
+      Organism,
+      Organism Part,
+      Cell Line,
+      Gene Name,
+      Gene Symbol,
+      Compound Name,
+      PubChem CID,
+      InChIKey,
+      Antibody,
+      Antibody Identifier,
+      Protein,
+      Pathology,
+      Pathology Identifier,
+      Phenotype,
+      Phenotype Term Accession,
+      siRNA Identifier,
+      siRNA Pool Identifier
+
  ---
 tags:
  -  Available values for a resourse key (attribute)
@@ -6,13 +38,18 @@ parameters:
   - name: resource_table
     in: path
     type: string
-    enum: ['image', 'project', 'screen', 'well', 'plate', 'all']
+    enum: ['image', 'project', 'screen', 'well', 'plate']
     required: true
   - name: key
     description: the resource attribute
     in: query
     type: string
     required: true
+  - name: csv
+    description: a flag to return a csv file which is created on the fly instead of json
+    in: query
+    type: boolean
+    required: false
 
 responses:
   200:

--- a/omero_search_engine/api/v1/resources/swagger_docs/searchvaluesusingkey.yml
+++ b/omero_search_engine/api/v1/resources/swagger_docs/searchvaluesusingkey.yml
@@ -1,5 +1,7 @@
 Get the available values for an attribute for one or all resources.
-This following is the most common attributes for each resource
+  It returns a JASON string containing the results.
+  It is possible to return a CSV file by setting the csv flag as true.
+The following are the most common attributes for each resource
 
    project:
       Imaging Method,
@@ -38,7 +40,7 @@ parameters:
   - name: resource_table
     in: path
     type: string
-    enum: ['image', 'project', 'screen', 'well', 'plate']
+    enum: ['image', 'project', 'screen', 'well', 'plate', 'all']
     required: true
   - name: key
     description: the resource attribute

--- a/omero_search_engine/api/v1/resources/urls.py
+++ b/omero_search_engine/api/v1/resources/urls.py
@@ -2,7 +2,7 @@ from . import resources
 from flask import request, jsonify
 import json
 from omero_search_engine.api.v1.resources.utils import search_resource_annotation, build_error_message
-from omero_search_engine.api.v1.resources.resourse_analyser import  search_value_for_resource,query_cashed_bucket, get_resource_attributes, get_resource_attribute_values, get_resource_names, get_values_for_a_key, query_cashed_bucket_value
+from omero_search_engine.api.v1.resources.resourse_analyser import  search_value_for_resource,query_cashed_bucket, get_resource_attributes, get_resource_attribute_values, get_resource_names, get_values_for_a_key, query_cashed_bucket_value,get_key_values_return_contents
 from omero_search_engine.api.v1.resources.utils import get_resource_annotation_table
 from omero_search_engine.api.v1.resources.query_handler import determine_search_results_, query_validator
 
@@ -104,11 +104,23 @@ def search_values_for_a_key(resource_table):
     """
     file: swagger_docs/searchvaluesusingkey.yml
     """
-
     key=request.args.get("key")
     if not key:
         return jsonify(build_error_message("No key is provided "))
-    return jsonify(query_cashed_bucket (key, resource_table))
+
+    #csv is a flag true of false,
+    #default is false
+    #if it sets to true, a sv file content will be sent insetead of dict
+    csv = request.args.get("csv")
+    if csv:
+        try:
+            csv = json.loads(csv.lower())
+        except:
+            csv = False
+
+    return get_key_values_return_contents(key, resource_table, csv)
+
+
 #getannotationkeys==> keys
 @resources.route('/<resource_table>/keys/',methods=['GET'])
 def get_resource_keys(resource_table):

--- a/omero_search_engine/validation/results_validator.py
+++ b/omero_search_engine/validation/results_validator.py
@@ -297,7 +297,7 @@ def test_no_images():
 
     report_file = os.path.join(base_folder, 'check_report.txt')
 
-    report=["\n======================== Test number of images inside each study ============================\n"]
+    report=["\n\n\n======================== Test number of images inside each study ============================\n"]
     for name, numbers in names.items():
         and_filters = [{"name": "Name (IDR number)", "value": name, "operator": "equals", "resource": "project"}]
         or_filtes = []
@@ -318,7 +318,7 @@ def test_no_images():
             message= "%s is fine, results [idr stats, searchengine]: %s"%(name, result)
         report.append(message)
     search_omero_app.logger.info(message)
-    report = "\n\n\n-----------------------------------------------------------------------------\n".join(report)
+    report = "\n-----------------------------------------------------------------------------\n".join(report)
     with open(report_file, 'a') as f:
         f.write(report)
 


### PR DESCRIPTION
Create a CSV file on the fly and send it to the user. It will use the existing endpoint API `/searchvaluesusingkey/`  to generate the file by setting the csv flag to true.

The default return for `/searchvaluesusingkey/` is still a JSON unless the csv flag is set as true.

It has been deployed on idr-testing. 

The following example returns a CSV  file which contains all the buckets for `Compound Name` with numbers 

idr-testing.openmicroscopy.org/searchengine/api/v1/resources/image/searchvaluesusingkey/?key=Compound Name&csv=true

![image](https://user-images.githubusercontent.com/9799944/179976624-0706d9e7-fd07-4516-94f6-27f4a2c06724.png)




























































