### PR TITLE
In operator

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,6 +69,7 @@ jobs:
           prefix: "${{ steps.getprefix.outputs.prefix }}"
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
+      - uses: actions/checkout@v2
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:
@@ -80,7 +81,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
-          file: ./deployment/docker/centos/Dockerfile
+          file: deployment/docker/centos/Dockerfile
           push: true
           tags: ${{ join(fromJson(steps.gettags.outputs.tags)) }}
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 repos:
   - repo: https://github.com/psf/black
-    rev: 22.6.0
+    rev: 22.8.0
     hooks:
       - id: black
         args: [--target-version=py35]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,27 @@
+0.3.0 (September 2022)
+----------------------
+- Add pagination section to the query results [#56](https://github.com/ome/omero_search_engine/pull/56).
+- Return the closest match first for a query using /searchvalues/ endpoint and subsequently include all possible matches [#53](https://github.com/ome/omero_search_engine/pull/53).
+- Searching for * or ? queries for strings containing those literal characters and they are not treated as wild-cards [#51](https://github.com/ome/omero_search_engine/pull/51).
+- Return containers (project or screen) which include image count and title for query results [#19](https://github.com/ome/omero_search_engine/pull/19) and [#41](https://github.com/ome/omero_search_engine/pull/41). 
+- Allow return number of the images for each value for a specific key [#40](https://github.com/ome/omero_search_engine/pull/40).
+- Fix issue of the "or" conditions [#38](https://github.com/ome/omero_search_engine/pull/38).
+- Fix the issues of getting resource names and unit tests [#28](https://github.com/ome/omero_search_engine/pull/28)17/Jul/2022).
+- Generate a csv file for the attribute buckets [#20](https://github.com/ome/omero_search_engine/pull/20).
+
+0.2.0 (June 2022)
+-----------------
+- Test indexing and queries [#17](https://github.com/ome/omero_search_engine/pull/17).
+- Improve documentation [#15](https://github.com/ome/omero_search_engine/pull/15).
+- Add "key sensitive" option [#14](https://github.com/ome/omero_search_engine/pull/14).
+- Reduce indexing time[#13](https://github.com/ome/omero_search_engine/pull/13). 
+- Add validation JSON schema for the search query.
+- Add the swagger documentations.
+- Search for any value.
+- Cache the value buckets for each key for each resource. 
+- Add submitquery endpoint.
+- Add Examples.
+
+0.1.0 (February 2022)
+---------------------
+- Initial release

--- a/app_data/test_index_data.json
+++ b/app_data/test_index_data.json
@@ -96,5 +96,16 @@
             "validation screen"
          ]
       ]
-   }
+   },
+    "query_in": {
+       "image": [
+          "Gene Symbol",
+          [
+             "Duoxa2",
+             "Bach2",
+             "Cxcr2",
+             "Mysm1"
+          ]
+       ]
+    }
 }

--- a/app_data/test_index_data.json
+++ b/app_data/test_index_data.json
@@ -99,6 +99,7 @@
    },
     "query_in": {
        "image": [
+         [
           "Gene Symbol",
           [
              "Duoxa2",
@@ -106,6 +107,16 @@
              "Cxcr2",
              "Mysm1"
           ]
+          ],
+          [
+          "Organism",
+          [
+             "homo sapiens",
+             "mus musculus",
+             "mus musculus x mus spretus",
+             "human adenovirus 2"
+          ]
        ]
+          ]
     }
 }

--- a/app_data/test_index_data.json
+++ b/app_data/test_index_data.json
@@ -66,6 +66,10 @@
             "hcc44"
          ],
          [
+            "cell line",
+            "hela"
+         ],
+         [
             "Cell Cycle Phase",
             "anaphase"
          ],

--- a/app_data/test_index_data.json
+++ b/app_data/test_index_data.json
@@ -22,6 +22,16 @@
                "Organism Part Identifier",
                "T-66000"
             ]
+         ],
+          [
+            [
+               "Antibody",
+               "nup133-aa566-582 antibody"
+            ],
+            [
+               "HGNC Gene Symbol",
+               "pdxdc1"
+            ]
          ]
       ],
       "query_image_and_or":[

--- a/examples/pagination_submitquery.py
+++ b/examples/pagination_submitquery.py
@@ -17,26 +17,36 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import datetime
 import logging
 import json
 import requests
 import sys
-import datetime
 from utils import base_url
 
-# url to send the query
-image_ext = "/resources/image/searchannotation/"
-# url to get the next page for a query, bookmark is needed
-image_page_ext = "/resources/image/searchannotation_page/"
+submit_query_url = f"{base_url}resources/submitquery/"  # noqa
 
 logging.basicConfig(stream=sys.stdout, level=logging.INFO)
+
 received_results = []
 page = 1
 ids = []
 total_pages = 0
+pagination_dict = None
+next_page = None
 
 
-def call_omero_return_results(url, data=None, method="post"):
+def get_current_page_bookmark(pagination_dict):
+    current_page = pagination_dict["current_page"]
+    bookmark = None
+    for page_rcd in pagination_dict["page_records"]:
+        if page_rcd["page"] == current_page:
+            bookmark = page_rcd["bookmark"]
+    return current_page, bookmark
+
+
+def call_omero_searchengine_return_results(url, data=None, method="post"):
+    global page, total_pages, pagination_dict, next_page
     if method == "post":
         resp = requests.post(url, data=data)
     else:
@@ -52,35 +62,37 @@ def call_omero_return_results(url, data=None, method="post"):
             sys.exit()
         # get the bookmark which will be used to call
         # the next page of the results
-        bookmark = returned_results["results"]["bookmark"]
+        pagination_dict = returned_results["results"].get("pagination")
+        page, bookmark = get_current_page_bookmark(pagination_dict)
+        page = pagination_dict.get("current_page")
         # get the size of the total results
+        total_pages = pagination_dict.get("total_pages")
+        next_page = pagination_dict.get("next_page")
+
         total_results = returned_results["results"]["size"]
+
         for res in returned_results["results"]["results"]:
             received_results.append(res)
             if res["id"] in ids:
-                raise Exception("Dublicated ids %s" % res["id"])
+                raise Exception(" Id dublicated error  %s" % res["id"])
             ids.append(res["id"])
-        global total_pages
-        total_pages = returned_results["results"]["total_pages"]
         return bookmark, total_results
 
     except Exception as ex:
         logging.info("Error: %s" % ex)
-        sys.exit()
 
 
 """
+If the user needs to search for unhealthy human female breast images
 
-If the user needs to search for unhealthy human female breast tissue images:
-
-Clause for Human:
+Clause for Human:  
 Organism='Homo sapiens' ==> {"name": "Organism", "value": "Homo sapiens", "operator": "equals","resource": "image"}  # noqa
 Restrict the search to "female":
-Sex='Female' ==> {"name": "Sex", "value": "Female", "operator": "equals","resource": "image"} # noqa
+Sex='Female' ==> {"name": "Sex", "value": "Female", "operator": "equals","resource": "image"}  # noqa
 Restrict the search to "breast":
-Organism Part='Breast' ==>{"name": "Organism Part", "value": "Breast", "operator": "equals","resource": "image"} # noqa
-Return only the images of "abnormal" tissues:
-Pathology != 'Normal tissue, NOS' ==> {"name": "Pathology", "value": "Normal tissue, NOS", "operator": "not_equals","resource": "image"} # noqa
+Organism Part='Breast' ==>{"name": "Organism Part", "value": "Breast", "operator": "equals","resource": "image"}  # noqa
+Return only the images of "abnormal" tissues: 
+Pathology != 'Normal tissue, NOS' ==> {"name": "Pathology", "value": "Normal tissue, NOS", "operator": "not_equals","resource": "image"}  # noqa
 In terms of clauses we only have and_filters which contains 4 clauses
 """
 start = datetime.datetime.now()
@@ -101,7 +113,7 @@ and_filters = [
     {
         "name": "Pathology",
         "value": "Normal tissue, NOS",
-        "operator": "not_equals",
+        "operator": "equals",
         "resource": "image",
     },
 ]
@@ -109,23 +121,23 @@ and_filters = [
 query_data = {"query_details": {"and_filters": and_filters}}
 
 query_data_json = json.dumps(query_data)
-# resp = requests.post(url="%s%s" % (base_url, image_ext),
-#                      data=query_data_json)
-bookmark, total_results = call_omero_return_results(
-    "%s%s" % (base_url, image_ext), data=query_data_json
+bookmark, total_results = call_omero_searchengine_return_results(
+    submit_query_url, data=query_data_json
+)
+logging.info(
+    "page: %s, / %s received results: %s / %s"
+    % (page, total_pages, len(received_results), total_results)
 )
 
-while len(received_results) < total_results:
-    page += 1
-    # add bookmark to the query, so it will return the next page
+while next_page:  # len(received_results) < total_results:
     query_data_ = {
-        "query": {"query_details": {"and_filters": and_filters}},
-        "bookmark": bookmark,
+        "query_details": {"and_filters": and_filters},
+        "pagination": pagination_dict,
     }
     query_data_json_ = json.dumps(query_data_)
-    # call the server
-    bookmark, total_results = call_omero_return_results(
-        "%s%s" % (base_url, image_page_ext), data=query_data_json_
+
+    bookmark, total_results = call_omero_searchengine_return_results(
+        submit_query_url, data=query_data_json_
     )
 
     logging.info(

--- a/examples/return_containers_only.py
+++ b/examples/return_containers_only.py
@@ -21,14 +21,10 @@ import logging
 import json
 import requests
 import sys
-
+from utils import base_url
 
 # url to send the query
 image_search = "/resources/image/search/"
-# search engine url
-base_url = "http://127.0.0.1:5577/api/v1/"
-# base_url ="https://idr-testing.openmicroscopy.org/searchengineapi/api/v1/"  # noqa
-
 
 logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 """

--- a/examples/return_containers_only.py
+++ b/examples/return_containers_only.py
@@ -44,7 +44,7 @@ curl -X GET "http://127.0.0.1:5577/api/v1/resources/image/search/?key=Organism&v
 
 page = 0
 ids = []
-logging.info(" Searching for: Organism Homo sapiens")
+logging.info("Searching for: Organism Homo sapiens")
 
 
 url = "%s%s?key=Organism&value=Homo sapiens&return_containers=true" % (
@@ -57,4 +57,7 @@ if returned_results.get("results"):
     if len(returned_results.get("results").get("results")) == 0:
         logging.info("No results is found")
     for item in returned_results.get("results").get("results"):
-        logging.info("Study: %s" % item.get("Name (IDR number)"))
+        logging.info(
+            "%s: %s contains %s images"
+            % (item.get("type"), item.get("name"), item.get("image count"))
+        )

--- a/examples/return_studies.py
+++ b/examples/return_studies.py
@@ -21,15 +21,10 @@ import logging
 import json
 import requests
 import sys
+from utils import base_url
 
 # url to send the query
-# search engine url
-submit_query_url = (
-    "http://127.0.0.1:5577/api/v1/resources/submitquery_returnstudies/"  # noqa
-)
-
-# base_url ="https://idr-testing.openmicroscopy.org/searchengineapi/api/v1/"
-
+submit_query_url = f"{base_url}resources/submitquery/containers/"
 
 logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 """
@@ -84,4 +79,4 @@ if returned_results.get("results"):
     if len(returned_results.get("results").get("results")) == 0:
         logging.info("No results is found")
     for item in returned_results.get("results").get("results"):
-        logging.info("Study: %s" % item.get("Name (IDR number)"))
+        logging.info("Study: %s" % item.get("name"))

--- a/examples/search-using_and_or_clauses.py
+++ b/examples/search-using_and_or_clauses.py
@@ -21,14 +21,13 @@ import logging
 import json
 import requests
 import sys
+from utils import base_url
 
 
 # url to send the query
 image_ext = "/resources/image/searchannotation/"
 # url to get the next page for a query, bookmark is needed
 image_page_ext = "/resources/image/searchannotation_page/"
-# search engine url
-base_url = "http://127.0.0.1:5577/api/v1/"
 
 
 logging.basicConfig(stream=sys.stdout, level=logging.INFO)

--- a/examples/search.py
+++ b/examples/search.py
@@ -88,5 +88,9 @@ while len(received_results) < total_results:
         % (len(received_results), total_results, page, total_pages, bookmark)
     )
 
-# 2000 /11686633, page: 1/11687, bookmark: 109600
-# 2000 /12225067, page: 1/12226, bookmark:  109600
+# another example using in operators and send items inside value as a string,
+# Items inside in the list are seprated by ','
+logging.info("Using in operator")
+url = "%s%s?key=Gene Symbol&value=Pdgfc,Rnase10&operator=in" % (base_url, image_search)
+bookmark, total_results, total_pages = call_omero_return_results(url, method="get")
+logging.info("%s,%s" % (total_results, total_pages))

--- a/examples/search.py
+++ b/examples/search.py
@@ -89,7 +89,7 @@ while len(received_results) < total_results:
     )
 
 # another example using in operators and send items inside value as a string,
-# Items inside in the list are seprated by ','
+# The List items are separated by ','
 logging.info("Using in operator")
 url = "%s%s?key=Gene Symbol&value=Pdgfc,Rnase10&operator=in" % (base_url, image_search)
 bookmark, total_results, total_pages = call_omero_return_results(url, method="get")

--- a/examples/search.py
+++ b/examples/search.py
@@ -22,12 +22,10 @@ import json
 import requests
 import sys
 
+from utils import base_url
 
 # url to send the query
 image_search = "/resources/image/search/"
-# search engine url
-# base_url = "http://127.0.0.1:5577/api/v1/"
-base_url = "https://idr-testing.openmicroscopy.org/searchengineapi/api/v1/"  # noqa
 
 
 logging.basicConfig(stream=sys.stdout, level=logging.INFO)

--- a/examples/search_for_values.py
+++ b/examples/search_for_values.py
@@ -21,28 +21,26 @@ import logging
 import json
 import requests
 import sys
+from utils import base_url
 
 # url to send the query
 image_value_search = "/resources/image/searchvalues/"
-# searchengine url
-base_url = "http://127.0.0.1:5577/api/v1/"
 logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 
 """
 If the user needs to search for a value whose attribute is not known e.g.
 search to find if diabetes is a part of any attribute values:
 """
+
+value = "diabetes"
 search_url = "%S/%s%value=diabetes"
 search_url = "{base_url}{image_value_search}?value={value}".format(
-    base_url=base_url, image_value_search=image_value_search, value="diabetes"
+    base_url=base_url, image_value_search=image_value_search, value=value
 )
 resp = requests.get(url=search_url)
 res = json.loads(resp.text)
-# total items
-logging.info("total_items: %s" % res.get("total_items"))
-logging.info("total_number: %s" % res.get("total_number"))
 # total number of buckets
-logging.info("Number of buckets: %s" % res.get("total_number_of_buckets"))
+logging.info("Total number of buckets: %s" % res.get("total_number_of_buckets"))
 # data
 data = res.get("data")
 logging.info("Number of buckets: %s" % len(data))

--- a/examples/search_for_values_bookmarks.py
+++ b/examples/search_for_values_bookmarks.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2022 University of Dundee & Open Microscopy Environment.
+# All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import logging
+import json
+import requests
+import sys
+import math
+from utils import base_url
+
+# url to send the query
+image_value_search = "/resources/image/searchvalues/"
+# searchengine url
+logging.basicConfig(stream=sys.stdout, level=logging.INFO)
+
+"""
+If the user needs to search for a value whose attribute is not known e.g.
+search to find if diabetes is a part of any attribute values:
+"""
+value = "pr"
+
+# url to send the query
+image_value_search = "/resources/image/searchvalues/"
+# searchengine url
+logging.basicConfig(stream=sys.stdout, level=logging.INFO)
+
+"""
+If the user needs to search for a value whose attribute is not known
+e.g. search to find if pr is a part of any attribute values and return
+all the possible matches:
+"""
+search_url = "{base_url}{image_value_search}?value={value}".format(
+    base_url=base_url, image_value_search=image_value_search, value=value
+)
+resp = requests.get(url=search_url)
+res = json.loads(resp.text)
+# total number of buckets
+# data
+data = res.get("data")
+buckets = []
+total_number_of_images = 0
+recieved_bukets = 0
+buckets = buckets + data
+
+resp = requests.get(url=search_url)
+res = json.loads(resp.text)
+# total number of buckets
+# data
+page = 1
+no_pages = math.ceil(res.get("total_number_of_all_buckets") / 9999)
+
+logging.info("Total number of images: %s" % res.get("total_number_of_image"))
+logging.info(
+    "Total number of returned buckets: %s" % res.get("total_number_of_buckets")
+)
+logging.info("Total number of all buckets: %s" % res.get("total_number_of_all_buckets"))
+
+bookmark = res.get("bookmark")
+if bookmark:
+    while True:
+        page += 1
+
+        bookmark = [str(item) for item in bookmark]
+        bookmark = ",".join(bookmark)
+        search_url = (
+            "{base_url}{image_value_search}?value={value}&bookmark={bookmark}".format(
+                base_url=base_url,
+                image_value_search=image_value_search,
+                value=value,
+                bookmark=bookmark,
+            )
+        )
+        resp = requests.get(url=search_url)
+        try:
+            ss = resp.text
+            res = json.loads(ss)
+        except Exception as e:
+            logging.info("Error %s" % str(e))
+            break
+        bookmark = res.get("bookmark")
+        if not bookmark:
+            break
+        data = res.get("data")
+        buckets = buckets + data
+        logging.info("Page %s/%s" % (page, no_pages))
+        logging.info("Total number of images: %s" % res.get("total_number_of_image"))
+        logging.info("No of buckets: %s" % res.get("total_number_of_buckets"))

--- a/examples/search_values_for_key.py
+++ b/examples/search_values_for_key.py
@@ -21,11 +21,10 @@ import logging
 import requests
 import json
 import sys
+from utils import base_url
 
 # url to send the query
 image_value_search = "/resources/image/searchvalues/"
-# search engine url
-base_url = "http://127.0.0.1:5577/api/v1/"
 logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 # Get the available attributes for a resource, e.g. image
 image_attributes = "/resources/image/keys/"
@@ -60,4 +59,5 @@ res = json.loads(resp.text)
 buckets = res.get("data")
 logging.info("Number of available buckets for attribute %s is %s" % (key, len(buckets)))
 # The first bucket
-logging.info("First bucket: %s " % buckets[0])
+for bucket in buckets:
+    logging.info("Bucket details: %s " % bucket)

--- a/examples/search_with_bookmark_paging_using_submitquery.py
+++ b/examples/search_with_bookmark_paging_using_submitquery.py
@@ -22,14 +22,10 @@ import logging
 import json
 import requests
 import sys
+from utils import base_url
 
-# url to send the query
-image_ext = "/resources/image/searchannotation/"
-# url to get the next page for a query, bookmark is needed
-image_page_ext = "/resources/image/searchannotation_page/"
-# search engine url
-base_url = "http://127.0.0.1:5577/api/v1/"
-submit_query_url = "http://127.0.0.1:5577/api/v1/resources/submitquery"  # noqa
+# search url
+submit_query_url = f"{base_url}resources/submitquery/"  # noqa
 
 
 logging.basicConfig(stream=sys.stdout, level=logging.INFO)
@@ -116,13 +112,18 @@ bookmark, total_results = call_omero_searchengine_return_results(
     submit_query_url, data=query_data_json
 )
 
+logging.info(
+    "page: %s, / %s received results: %s / %s"
+    % (page, total_pages, len(received_results), total_results)
+)
+
 while len(received_results) < total_results:
 
     page += 1
     query_data_ = {"query_details": {"and_filters": and_filters}, "bookmark": bookmark}
     query_data_json_ = json.dumps(query_data_)
 
-    bookmark, total_results = call_omero_searchengine_return_results(
+    next_bookmark, total_results = call_omero_searchengine_return_results(
         submit_query_url, data=query_data_json_
     )
 
@@ -130,3 +131,4 @@ while len(received_results) < total_results:
         "bookmark: %s, page: %s, / %s received results: %s / %s"
         % (bookmark, page, total_pages, len(received_results), total_results)
     )
+    bookmark = next_bookmark

--- a/examples/using_in_oprators.py
+++ b/examples/using_in_oprators.py
@@ -30,7 +30,9 @@ logging.info("Exmple of using in operator")
 
 
 values_in = ["Duoxa2", "Bach2", "Cxcr2", "Mysm1"]
-logging.info("Searching for 'Gene Symbol' which its values in [%s]"%(','.join(values_in)))
+logging.info(
+    "Searching for 'Gene Symbol' which its values in [%s]" % (",".join(values_in))
+)
 and_filters = [{"name": "Gene Symbol", "value": values_in, "operator": "in"}]
 
 main_attributes = []

--- a/examples/using_in_oprators.py
+++ b/examples/using_in_oprators.py
@@ -27,7 +27,10 @@ from utils import query_the_search_ending, logging
 # and filters
 
 logging.info("Exmple of using in operator")
+
+
 values_in = ["Duoxa2", "Bach2", "Cxcr2", "Mysm1"]
+logging.info("Searching for 'Gene Symbol' which its values in [%s]"%(','.join(values_in)))
 and_filters = [{"name": "Gene Symbol", "value": values_in, "operator": "in"}]
 
 main_attributes = []

--- a/examples/using_in_oprators.py
+++ b/examples/using_in_oprators.py
@@ -20,9 +20,12 @@
 
 from utils import query_the_search_ending, logging
 
-# It is similar to use in operator in sql statment
-# Find images of cells where gene symbole
-# and provide a list which contains values
+# It is similar to use 'in operator' in a sql statement,
+# rather than having multiple 'or' conditions,
+# it will use onle a single condition.
+
+# The following example will search for the images which have any of the 'Gene Symbol'
+# values in this list "Duoxa2", "Bach2", "Cxcr2", "Mysm1"]
 
 # and filters
 

--- a/examples/using_in_oprators.py
+++ b/examples/using_in_oprators.py
@@ -22,14 +22,14 @@ from utils import query_the_search_ending, logging
 
 # It is similar to use 'in operator' in a sql statement,
 # rather than having multiple 'or' conditions,
-# it will use onle a single condition.
+# it will only use a single condition.
 
 # The following example will search for the images which have any of the 'Gene Symbol'
-# values in this list "Duoxa2", "Bach2", "Cxcr2", "Mysm1"]
+# values in this list ["Duoxa2", "Bach2", "Cxcr2", "Mysm1"]
 
 # and filters
 
-logging.info("Exmple of using in operator")
+logging.info("Example of using in operator")
 
 
 values_in = ["Duoxa2", "Bach2", "Cxcr2", "Mysm1"]

--- a/examples/using_in_oprators.py
+++ b/examples/using_in_oprators.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2022 University of Dundee & Open Microscopy Environment.
+# All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+from utils import query_the_search_ending, logging
+
+# It is similar to use in operator in sql statment
+# Find images of cells where gene symbole
+# and provide a list which contains values
+
+# and filters
+
+logging.info("Exmple of using in operator")
+values_in = ["Duoxa2", "Bach2", "Cxcr2", "Mysm1"]
+and_filters = [{"name": "Gene Symbol", "value": values_in, "operator": "in"}]
+
+main_attributes = []
+query = {"and_filters": and_filters}
+#
+recieved_results_data = query_the_search_ending(query, main_attributes)

--- a/examples/using_not_in_operator.py
+++ b/examples/using_not_in_operator.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2022 University of Dundee & Open Microscopy Environment.
+# All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+from utils import query_the_search_ending, logging
+
+# It is similar to use 'not in' operator in a sql statement,
+# rather than having multiple 'or' conditions with not_equals operators,
+# it will only use a single condition.
+
+# The following example will search for the images which have mpt any of the 'Organism'
+# values in this list ["homo sapiens","mus musculus","mus musculus x mus spretus","human adenovirus 2"]
+
+# and filters
+
+logging.info("Example of using not_in operator")
+
+
+
+values_not_in = ["homo sapiens","mus musculus","mus musculus x mus spretus","human adenovirus 2"]
+logging.info(
+    "Searching for 'Organism' which its values in [%s]" % (",".join(values_not_in))
+)
+and_filters = [{"name": "Organism", "value": values_not_in, "operator": "not_in"}]
+
+main_attributes = []
+query = {"and_filters": and_filters}
+#
+recieved_results_data = query_the_search_ending(query, main_attributes)

--- a/examples/using_not_in_operator.py
+++ b/examples/using_not_in_operator.py
@@ -25,15 +25,20 @@ from utils import query_the_search_ending, logging
 # it will only use a single condition.
 
 # The following example will search for the images which have mpt any of the 'Organism'
-# values in this list ["homo sapiens","mus musculus","mus musculus x mus spretus","human adenovirus 2"]
+# values in this list
+# ["homo sapiens","mus musculus","mus musculus x mus spretus","human adenovirus 2"]
 
 # and filters
 
 logging.info("Example of using not_in operator")
 
 
-
-values_not_in = ["homo sapiens","mus musculus","mus musculus x mus spretus","human adenovirus 2"]
+values_not_in = [
+    "homo sapiens",
+    "mus musculus",
+    "mus musculus x mus spretus",
+    "human adenovirus 2",
+]
 logging.info(
     "Searching for 'Organism' which its values in [%s]" % (",".join(values_not_in))
 )

--- a/omero_search_engine/api/v1/resources/data/restricted_search_terms.json
+++ b/omero_search_engine/api/v1/resources/data/restricted_search_terms.json
@@ -12,10 +12,8 @@
       "Screen Type"
    ],
    "image":[
-      "Organism",
-      "Organism Part",
       "Cell Line",
-      "Gene Name",
+      "Gene Identifier",
       "Gene Symbol",
       "Compound Name",
       "PubChem CID",

--- a/omero_search_engine/api/v1/resources/query_handler.py
+++ b/omero_search_engine/api/v1/resources/query_handler.py
@@ -292,12 +292,15 @@ class QueryRunner(
 
         if query_.get("or_filters"):
             qq = []
-            query.get("or_filters").append(qq)
             for qu_ in query_.get("or_filters"):
                 if isinstance(qu_, list):
+                    tmpss = []
+                    query.get("or_filters").append(tmpss)
                     for qu in qu_:
-                        qq.append(qu.__dict__)
+                        tmpss.append(qu.__dict__)
                 else:
+                    if qq not in query.get("or_filters"):
+                        query.get("or_filters").append(qq)
                     qq.append(qu_.__dict__)
 
         if query_.get("main_attribute"):

--- a/omero_search_engine/api/v1/resources/query_handler.py
+++ b/omero_search_engine/api/v1/resources/query_handler.py
@@ -158,6 +158,7 @@ class QueryRunner(
         or_query_group,
         case_sensitive,
         bookmark,
+        pagination_dict,
         raw_elasticsearch_query,
         columns_def,
         return_columns,
@@ -167,6 +168,7 @@ class QueryRunner(
         self.and_query_group = and_query_group
         self.case_sensitive = case_sensitive
         self.bookmark = bookmark
+        self.pagination_dict = pagination_dict
         self.columns_def = columns_def
         self.raw_elasticsearch_query = raw_elasticsearch_query
         self.image_query = {}
@@ -333,8 +335,10 @@ class QueryRunner(
         #    return {"Error": "Your query returns no results"}
         if resource == "image":
             bookmark = self.bookmark
+            pagination_dict = self.pagination_dict
         else:
             bookmark = None
+            pagination_dict = None
 
         # res = search_query(query, resource, bookmark,
         #                    self.raw_elasticsearch_query,
@@ -344,13 +348,19 @@ class QueryRunner(
                 query,
                 resource,
                 bookmark,
+                pagination_dict,
                 self.raw_elasticsearch_query,
                 main_attributes,
                 return_containers=self.return_containers,
             )
         else:
             res = search_query(
-                query, resource, bookmark, self.raw_elasticsearch_query, main_attributes
+                query,
+                resource,
+                bookmark,
+                pagination_dict,
+                self.raw_elasticsearch_query,
+                main_attributes,
             )
 
         if resource != "image":
@@ -365,6 +375,7 @@ def search_query(
     query,
     resource,
     bookmark,
+    pagination_dict,
     raw_elasticsearch_query,
     main_attributes=None,
     return_containers=False,
@@ -386,15 +397,16 @@ def search_query(
     else:
         q_data = {"query": {"query_details": query, "main_attributes": main_attributes}}
     try:
-        if bookmark:
+        if bookmark or pagination_dict:
             q_data["bookmark"] = bookmark
+            q_data["pagination"] = pagination_dict
             q_data["raw_elasticsearch_query"] = raw_elasticsearch_query
             ress = search_resource_annotation(
                 resource,
                 q_data.get("query"),
                 raw_elasticsearch_query=raw_elasticsearch_query,
-                page=query.get("page"),
                 bookmark=bookmark,
+                pagination_dict=pagination_dict,
                 return_containers=return_containers,
             )
         else:
@@ -552,6 +564,7 @@ def determine_search_results_(query_, return_columns=False, return_containers=Fa
         case_sensitive = False
 
     bookmark = query_.get("bookmark")
+    pagination_dict = query_.get("pagination")
     raw_elasticsearch_query = query_.get("raw_elasticsearch_query")
     and_filters = query_.get("query_details").get("and_filters")
     or_filters = query_.get("query_details").get("or_filters")
@@ -605,6 +618,7 @@ def determine_search_results_(query_, return_columns=False, return_containers=Fa
         or_query_groups,
         case_sensitive,
         bookmark,
+        pagination_dict,
         raw_elasticsearch_query,
         columns_def,
         return_columns,

--- a/omero_search_engine/api/v1/resources/resource_analyser.py
+++ b/omero_search_engine/api/v1/resources/resource_analyser.py
@@ -480,7 +480,7 @@ def search_value_for_resource(table_, value, es_index="key_value_buckets_informa
             value = value.replace("\\", "\\\\")
         value = "*{value}*".format(value=value)
         query = resource_key_values_buckets_template.substitute(
-            value=value, resource="image"
+            value=value, resource=table_
         )
         res = search_index_for_value(es_index, query)
         return prepare_search_results(res)

--- a/omero_search_engine/api/v1/resources/resource_analyser.py
+++ b/omero_search_engine/api/v1/resources/resource_analyser.py
@@ -336,16 +336,18 @@ def prepare_search_results(results, size=0):
         "total_number_of_%s" % (resource): total_number,
         "total_number_of_buckets": number_of_buckets,
     }
-
     if size > 0:
-        results_dict["total_number_of_all_buckets "] = size
+        results_dict["total_number_of_all_buckets"] = size
         if number_of_buckets < size:
             # this should be later to get the next page
-            results_dict["bookmark"] = [
-                int(results["hits"]["hits"][-1]["sort"][0]),
-                int(results["hits"]["hits"][-1]["sort"][1]),
-                results["hits"]["hits"][-1]["sort"][2],
-            ]
+            if len(results["hits"]["hits"]) > 0:
+                results_dict["bookmark"] = [
+                    int(results["hits"]["hits"][-1]["sort"][0]),
+                    int(results["hits"]["hits"][-1]["sort"][1]),
+                    results["hits"]["hits"][-1]["sort"][2],
+                ]
+            else:
+                results_dict["bookmark"] = None
     return results_dict
 
 
@@ -475,7 +477,9 @@ def query_cashed_bucket_value(value, es_index="key_value_buckets_information"):
     return prepare_search_results(res)
 
 
-def search_value_for_resource(table_, value, es_index="key_value_buckets_information"):
+def search_value_for_resource(
+    table_, value, bookmarks=None, es_index="key_value_buckets_information"
+):
     """
     send the request to elasticsearch and format the results
     It support wildcard operations only
@@ -492,12 +496,14 @@ def search_value_for_resource(table_, value, es_index="key_value_buckets_informa
         # Get the total number of the results.
         res = search_index_for_value(es_index, size_query, True)
         size = res["count"]
+        # use bookmark is it is provided
+        if bookmarks:
+            query = json.loads(query)
+            query["search_after"] = bookmarks
+
         res = search_index_for_value(es_index, query)
         return prepare_search_results(res, size)
     else:
-        # If the user does not specify anything,
-        # it will add * at the start and at the end to
-        # return all the values which contain the search term
         returned_results = {}
         for table in resource_elasticsearchindex:
             # ignore image1 as it is used for testing
@@ -507,9 +513,14 @@ def search_value_for_resource(table_, value, es_index="key_value_buckets_informa
             query = resource_key_values_buckets_template.substitute(
                 value=value, resource=table
             )
-
+            size_query = resource_key_values_buckets_size_template.substitute(
+                value=value, resource=table_
+            )
+            # Get the total number of the results.
+            res = search_index_for_value(es_index, size_query, True)
+            size = res["count"]
             res = search_index_for_value(es_index, query)
-            returned_results[table] = prepare_search_results(res)
+            returned_results[table] = prepare_search_results(res, size)
         return returned_results
 
 

--- a/omero_search_engine/api/v1/resources/resource_analyser.py
+++ b/omero_search_engine/api/v1/resources/resource_analyser.py
@@ -95,7 +95,7 @@ values_for_key_template = Template(
 )
 
 
-def search_index_for_value(e_index, query):
+def search_index_for_value(e_index, query, get_size=False):
     """
     Perform search the elastcisearch using value and
     return all the key values whihch this value has been used,
@@ -104,6 +104,8 @@ def search_index_for_value(e_index, query):
     to the elasticsearcg hosting machine
     """
     es = search_omero_app.config.get("es_connector")
+    if get_size:
+        return es.count(index=e_index, body=query)
     res = es.search(index=e_index, body=query)
     return res
 
@@ -125,7 +127,17 @@ def search_index_for_values_get_all_buckets(e_index, query):
     # res = es.count(index=e_index, body=query)
     size = res["count"]
     query["size"] = page_size
-    query["sort"] = [{"id": "asc"}]
+    query["sort"] = [
+        {
+            "_script": {
+                "script": "doc['Value.keyvaluenormalize'].value.length()",
+                "type": "number",
+                "order": "asc",
+            }
+        },
+        {"items_in_the_bucket": "desc"},
+        {"id": "asc"},
+    ]
     co = 0
     while co < size:
         if co != 0:
@@ -143,7 +155,11 @@ def search_index_for_values_get_all_buckets(e_index, query):
                 % (co, size)
             )
             return returened_results
-        bookmark = [res["hits"]["hits"][-1]["sort"][0]]
+        bookmark = [
+            int(res["hits"]["hits"][-1]["sort"][0]),
+            int(res["hits"]["hits"][-1]["sort"][1]),
+            res["hits"]["hits"][-1]["sort"][2],
+        ]
     return returened_results
 
 
@@ -290,7 +306,7 @@ def get_values_for_a_key(table_, key):
     }
 
 
-def prepare_search_results(results):
+def prepare_search_results(results, size=0):
     returned_results = []
     total_number = 0
     number_of_buckets = 0
@@ -314,18 +330,28 @@ def prepare_search_results(results):
         row["Number of %ss" % resource] = res.get("items_in_the_bucket")
         total_number += res["items_in_the_bucket"]
         number_of_buckets += 1
-    return {
+
+    results_dict = {
         "data": returned_results,
         "total_number_of_%s" % (resource): total_number,
         "total_number_of_buckets": number_of_buckets,
     }
 
+    if size > 0:
+        results_dict["total_number_of_all_buckets "] = size
+        if number_of_buckets < size:
+            # this should be later to get the next page
+            results_dict["bookmark"] = [
+                int(results["hits"]["hits"][-1]["sort"][0]),
+                int(results["hits"]["hits"][-1]["sort"][1]),
+                results["hits"]["hits"][-1]["sort"][2],
+            ]
+    return results_dict
+
 
 def prepare_search_results_buckets(results_):
     returned_results = []
-    total = 0
     total_number = 0
-    total_items = 0
     number_of_buckets = 0
     resource = None
     for results in results_:
@@ -337,15 +363,12 @@ def prepare_search_results_buckets(results_):
             row["Value"] = res["Value"]
             resource = res.get("resource")
             row["Number of %ss" % resource] = res.get("items_in_the_bucket")
-            total_number = res["total_items_in_saved_buckets"]
-            number_of_buckets = res["total_buckets"]
-            total_items = res["total_items"]
+            total_number += res["items_in_the_bucket"]
+            number_of_buckets += 1
     return {
         "data": returned_results,
-        "total_number": total_number,
-        "total_number_of_%s" % (resource): total,
+        "total_number_of_%s" % (resource): total_number,
         "total_number_of_buckets": number_of_buckets,
-        "total_items": total_items,
     }
 
 
@@ -463,9 +486,14 @@ def search_value_for_resource(table_, value, es_index="key_value_buckets_informa
         query = resource_key_values_buckets_template.substitute(
             value=value, resource=table_
         )
+        size_query = resource_key_values_buckets_size_template.substitute(
+            value=value, resource=table_
+        )
+        # Get the total number of the results.
+        res = search_index_for_value(es_index, size_query, True)
+        size = res["count"]
         res = search_index_for_value(es_index, query)
-
-        return prepare_search_results(res)
+        return prepare_search_results(res, size)
     else:
         # If the user does not specify anything,
         # it will add * at the start and at the end to
@@ -544,6 +572,13 @@ value_all_buckets_template = Template(
 {"Value.keyvaluenormalize":"*$value*"}}}}]}},"size": 9999}"""
 )
 
+resource_key_values_buckets_size_template = Template(
+    """
+{"query":{"bool":{"must":[{"bool":{
+"must":{"wildcard":{"Value.keyvaluenormalize":"*$value*"}}}},{
+"bool": {"must": {"match":
+{"resource.keyresource": "$resource"}}}}]}}}"""
+)
 
 resource_key_values_buckets_template = Template(
     """
@@ -551,9 +586,12 @@ resource_key_values_buckets_template = Template(
 "must":{"wildcard":{"Value.keyvaluenormalize":"*$value*"}}}},{
 "bool": {"must": {"match":
 {"resource.keyresource": "$resource"}}}}]}},
-"size": 9999, "sort": [{"items_in_the_bucket": "desc"}]}"""
+"size": 9999, "sort":[{ "_script": {
+        "script": "doc['Value.keyvaluenormalize'].value.length()",
+        "type": "number",
+        "order": "asc"
+    }},{"items_in_the_bucket": "desc"}, {"id": "asc"}]}"""
 )
-
 
 key_values_buckets_template_2 = Template(
     """

--- a/omero_search_engine/api/v1/resources/resource_analyser.py
+++ b/omero_search_engine/api/v1/resources/resource_analyser.py
@@ -573,7 +573,7 @@ resource_key_values_buckets_template = Template(
 "must":{"wildcard":{"Value.keyvaluenormalize":"$value"}}}},{
 "bool": {"must": {"match":
 {"resource.keyresource": "$resource"}}}}]}},
-"size": 9999}"""
+"size": 9999, "sort": [{"items_in_the_bucket": "desc"}]}"""
 )
 
 

--- a/omero_search_engine/api/v1/resources/schemas/filter_schema.json
+++ b/omero_search_engine/api/v1/resources/schemas/filter_schema.json
@@ -18,7 +18,7 @@
      "operator": {
       "name": "operator",
       "type": "string",
-      "enum": ["equals", "not_equals", "contains","not_contains","in"]
+      "enum": ["equals", "not_equals", "contains","not_contains","in","not_in"]
     }
      ,"resource": {
       "name": "resource",

--- a/omero_search_engine/api/v1/resources/schemas/filter_schema.json
+++ b/omero_search_engine/api/v1/resources/schemas/filter_schema.json
@@ -13,12 +13,12 @@
     },
      "value": {
       "name":"value",
-      "type": "string"
+      "type": ["array", "string"]
     },
      "operator": {
       "name": "operator",
       "type": "string",
-      "enum": ["equals", "not_equals", "contains","not_contains"]
+      "enum": ["equals", "not_equals", "contains","not_contains","in"]
     }
      ,"resource": {
       "name": "resource",
@@ -27,4 +27,3 @@
     }
     }
   }
-

--- a/omero_search_engine/api/v1/resources/swagger_docs/search.yml
+++ b/omero_search_engine/api/v1/resources/swagger_docs/search.yml
@@ -28,7 +28,7 @@ parameters:
     description: operator, default equals
     in: query
     type: string
-    enum: ['equals', 'not_equals', 'contains', 'not_contains']
+    enum: ['equals', 'not_equals', 'contains', 'not_contains','in']
   - name: case_sensitive
     description: case sensitive query, default False
     in: query

--- a/omero_search_engine/api/v1/resources/swagger_docs/search_for_any_value.yml
+++ b/omero_search_engine/api/v1/resources/swagger_docs/search_for_any_value.yml
@@ -1,4 +1,5 @@
-Search for a value whose attribute is not known.
+Search for a value whose attribute is not known. if a key (attribute) is submitted, it will search for and obtain the available values for an attribute and part of the value for one or all resources e.g. 'homo' to return all values which contain 'homo' for the provided attribute and resource.
+It returns a JSON string containing the results.
 ---
 tags:
  - Search for any value
@@ -13,6 +14,11 @@ parameters:
     in: query
     type: string
     required: true
+  - name: key
+    description: search term
+    in: query
+    type: string
+    required: false
 definitions:
  data:
     type: object

--- a/omero_search_engine/api/v1/resources/swagger_docs/search_for_any_value.yml
+++ b/omero_search_engine/api/v1/resources/swagger_docs/search_for_any_value.yml
@@ -14,6 +14,11 @@ parameters:
     in: query
     type: string
     required: true
+  - name: bookmark
+    description: search term (should not be used with "all" or key is present), a comma-delimited string, e.g. 4,9, 44a90c1a-3271-448a-ba60-c391f885bc34
+    in: query
+    type: string
+    required: false
   - name: key
     description: search term
     in: query

--- a/omero_search_engine/api/v1/resources/swagger_docs/submitquery.yml
+++ b/omero_search_engine/api/v1/resources/swagger_docs/submitquery.yml
@@ -26,7 +26,8 @@ Example:
     }
 
 
-The maximum number of returned results is 1000, so if the number of results is bigger than that, a bookmark should be added to the query to call the next page. bookmark is returned with each page of results and should be used to call the next page.
+The maximum number of returned results is 1000, so if the number of results is bigger than that, a `bookmark` should be added to the query to call the next page.
+`bookmark` is returned with each page of results and should be used to call the next page.
 Example of using bookmark:
 
   {
@@ -50,6 +51,45 @@ Example of using bookmark:
   [107448]
 
   }
+
+There is a dict (`pagination`)  is returned with results.
+It can be sent back with the query when calling the next page.
+Then the server will update it and send it again along with the results to the client.
+Example of using pagination:
+
+{
+"resource":"image",
+"query_details":{
+"and_filters":[
+{
+"name":"Cell Line",
+"operator":"equals",
+"query_type":"keyvalue",
+"resource":"image",
+"value":"hela"
+}
+],
+"case_sensitive":false,
+"or_filters":[
+
+]
+},
+"pagination": {
+      "current_page": 1,
+      "next_page": 2,
+      "page_records": [
+        {
+          "bookmark": [
+            107448
+          ],
+          "page": 2
+        }
+      ],
+      "total_pages": 1578
+    }
+
+}
+
 ---
 tags:
  - Mixed Complex query

--- a/omero_search_engine/api/v1/resources/swagger_docs/submitquery.yml
+++ b/omero_search_engine/api/v1/resources/swagger_docs/submitquery.yml
@@ -25,6 +25,30 @@ Example:
      }
     }
 
+Another example uses 'in' operator:
+{
+   "query_details":{
+      "and_filters":[
+         {
+            "name":"Gene Symbol",
+            "value":[
+               "Duoxa2",
+               "Bach2",
+               "Cxcr2",
+               "Mysm1"
+            ],
+            "operator":"in",
+            "resource":"image"
+         },
+        {
+           "name": "Name (IDR number)",
+           "value": "idr0043-uhlen-humanproteinatlas/experimentA",
+           "operator": "equals",
+           "resource": "project"
+         }
+      ]
+   }
+}
 
 The maximum number of returned results is 1000, so if the number of results is bigger than that, a `bookmark` should be added to the query to call the next page.
 `bookmark` is returned with each page of results and should be used to call the next page.

--- a/omero_search_engine/api/v1/resources/urls.py
+++ b/omero_search_engine/api/v1/resources/urls.py
@@ -30,6 +30,7 @@ from omero_search_engine.api.v1.resources.resource_analyser import (
     get_resource_attribute_values,
     get_resource_names,
     get_key_values_return_contents,
+    query_cashed_bucket_part_value_keys,
 )
 from omero_search_engine.api.v1.resources.utils import get_resource_annotation_table
 from omero_search_engine.api.v1.resources.query_handler import (
@@ -180,7 +181,12 @@ def get_values_using_value(resource_table):
             build_error_message("Error: {error}".format(error="No value is provided "))
         )
     # print (value, resource_table)
-    return jsonify(search_value_for_resource(resource_table, value))
+    key = request.args.get("key")
+    if key:
+        # If the key is provided it will restrict the search to the provided key.
+        return query_cashed_bucket_part_value_keys(key, value, resource_table)
+    else:
+        return jsonify(search_value_for_resource(resource_table, value))
 
 
 @resources.route("/<resource_table>/searchvaluesusingkey/", methods=["GET"])

--- a/omero_search_engine/api/v1/resources/urls.py
+++ b/omero_search_engine/api/v1/resources/urls.py
@@ -76,9 +76,9 @@ def search_resource_page(resource_table):
         query = data["query"]
         validation_results = query_validator(query)
         if validation_results == "OK":
-            page = data.get("page")
             bookmark = data.get("bookmark")
             raw_elasticsearch_query = data.get("raw_elasticsearch_query")
+            pagination_dict = data.get("pagination")
             return_containers = data.get("return_containers")
             if return_containers:
                 return_containers = json.loads(return_containers.lower())
@@ -87,8 +87,8 @@ def search_resource_page(resource_table):
                 resource_table,
                 query,
                 raw_elasticsearch_query=raw_elasticsearch_query,
-                page=page,
                 bookmark=bookmark,
+                pagination_dict=pagination_dict,
                 return_containers=return_containers,
             )
             return jsonify(resource_list)
@@ -193,8 +193,37 @@ def get_values_using_value(resource_table):
     if key:
         # If the key is provided it will restrict the search to the provided key.
         return query_cashed_bucket_part_value_keys(key, value, resource_table)
-    else:
-        return jsonify(search_value_for_resource(resource_table, value))
+    bookmark = request.args.get("bookmark")
+    if bookmark:
+        bookmark = bookmark.split(",")
+        if bookmark and resource_table == "all":
+            return jsonify(
+                build_error_message(
+                    "{error}".format(
+                        error="Boomark is not supported 'all', "
+                        "it should be used with individual resources"
+                    )
+                )
+            )
+
+        if len(bookmark) != 3:
+            return jsonify(
+                build_error_message(
+                    "{error}".format(
+                        error="Bookmark should be a comma-delimited string, "
+                        "e.g. 4,9,44a90c1a-3271-448a-ba60-c391f885bc34"
+                    )
+                )
+            )
+        if not bookmark[0].isdigit() or not bookmark[1].isdigit():
+            return jsonify(
+                build_error_message(
+                    "{error}".format(
+                        error="The first two items in the bookmark should be intgers"
+                    )
+                )
+            )
+    return jsonify(search_value_for_resource(resource_table, value, bookmark))
 
 
 @resources.route("/<resource_table>/searchvaluesusingkey/", methods=["GET"])

--- a/omero_search_engine/api/v1/resources/urls.py
+++ b/omero_search_engine/api/v1/resources/urls.py
@@ -271,7 +271,7 @@ def get_resource_names_(resource_table):
     return jsonify(names)
 
 
-@resources.route("/submitquery_returnstudies/", methods=["POST"])
+@resources.route("/submitquery/containers/", methods=["POST"])
 def submit_query_return_containers():
     """
     file: swagger_docs/submitquery_returncontainers.yml

--- a/omero_search_engine/api/v1/resources/urls.py
+++ b/omero_search_engine/api/v1/resources/urls.py
@@ -18,7 +18,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from . import resources
-from flask import request, jsonify
+from flask import request, jsonify, make_response
 import json
 from omero_search_engine.api.v1.resources.utils import (
     search_resource_annotation,
@@ -50,12 +50,12 @@ def search_resource_page(resource_table):
     """
     used to get the next results page
     """
-    if not (get_resource_annotation_table):
-        return jsonify(
-            build_error_message(
-                "No data for table {table}".format(table=resource_table)
-            )
-        )
+    if not (get_resource_annotation_table(resource_table)):
+        resp_message = "No data for table {table}".format(table=resource_table)
+        response = make_response(resp_message, 404)
+        response.mimetype = "text/plain"
+        return response
+
     data = request.data
     if not data:
         return jsonify(
@@ -124,12 +124,12 @@ def search_resource(resource_table):
        or_filters means that the results should satisfy at least one condition inside the filters
     """
 
-    if not (get_resource_annotation_table):
-        return jsonify(
-            build_error_message(
-                "NO data for table {table}".format(table=resource_table)
-            )
-        )
+    if not (get_resource_annotation_table(resource_table)):
+        resp_message = "No data for table {table}".format(table=resource_table)
+        response = make_response(resp_message, 404)
+        response.mimetype = "text/plain"
+        return response
+
     data = request.data
     if not data:
         return jsonify(
@@ -180,6 +180,14 @@ def get_values_using_value(resource_table):
         return jsonify(
             build_error_message("Error: {error}".format(error="No value is provided "))
         )
+    # check if resource_table is vaild
+    if not (get_resource_annotation_table(resource_table)):
+        # If the resource does not exist, it will return a 404 with a message.
+        resp_message = "No data for table {table}".format(table=resource_table)
+        response = make_response(resp_message, 404)
+        response.mimetype = "text/plain"
+        return response
+
     # print (value, resource_table)
     key = request.args.get("key")
     if key:
@@ -254,7 +262,10 @@ def get_resource_names_(resource_table):
     Query the available attributes for a specific resource
     """
     if not (get_resource_annotation_table(resource_table)):
-        return "NO data for table {table}".format(table=resource_table)
+        resp_message = "No data for table {table}".format(table=resource_table)
+        response = make_response(resp_message, 404)
+        response.mimetype = "text/plain"
+        return response
 
     names = get_resource_names(resource_table)
     return jsonify(names)

--- a/omero_search_engine/api/v1/resources/utils.py
+++ b/omero_search_engine/api/v1/resources/utils.py
@@ -125,6 +125,12 @@ case_sensitive_must_value_condition_template = Template(
 {"match": {"key_values.value.keyvalue":"$value"}}"""
 )
 
+nested_query_template_must_must_not = Template(
+    """
+{"nested": {"path": "key_values",
+"query":{"bool": {"must":[$must_part], "must_not":[$must_not_part]}}}}"""
+)
+
 # in opeartor
 case_sensitive_must_in_value_condition_template = Template(
     """
@@ -384,38 +390,28 @@ def elasticsearch_query_builder(
 
             if operator == "not_in":
                 if case_sensitive:
-                    nested_must_not_part.append(
-                        nested_keyvalue_pair_query_template.substitute(
-                            nested=case_sensitive_must_in_value_condition_template.substitute(  # noqa
+                    nested_must_part.append(
+                        nested_query_template_must_must_not.substitute(
+                            must_not_part=case_sensitive_must_in_value_condition_template.substitute(  # noqa
                                 value=value
-                            )
+                            ),
+                            must_part=case_sensitive_must_name_condition_template.substitute(  # noqa
+                                name=key
+                            ),
                         )
                     )
-
-                    nested_must_part.append(
-                        nested_keyvalue_pair_query_template.substitute(
-                            nested=case_sensitive_must_name_condition_template.substitute(  # noqa
-                                name=key
-                            )
-                        )
-                    )  # noqa
 
                 else:
-                    nested_must_not_part.append(
-                        nested_keyvalue_pair_query_template.substitute(
-                            nested=case_insensitive_must_in_value_condition_template.substitute(  # noqa
+                    nested_must_part.append(
+                        nested_query_template_must_must_not.substitute(
+                            must_not_part=case_insensitive_must_in_value_condition_template.substitute(  # noqa
                                 value=value
-                            )
+                            ),
+                            must_part=case_insensitive_must_name_condition_template.substitute(  # noqa
+                                name=key
+                            ),
                         )
                     )
-
-                    nested_must_part.append(
-                        nested_keyvalue_pair_query_template.substitute(
-                            nested=case_insensitive_must_name_condition_template.substitute(  # noqa
-                                name=key
-                            )
-                        )
-                    )  # noqa
 
             if operator == "contains":
                 value = "*{value}*".format(value=adjust_value(value))
@@ -455,64 +451,50 @@ def elasticsearch_query_builder(
                     value = "*{value}*".format(value=adjust_value(value))
                     if case_sensitive:
                         nested_must_part.append(
-                            nested_keyvalue_pair_query_template.substitute(
-                                nested=case_sensitive_must_name_condition_template.substitute(  # noqa
-                                    name=key
-                                )
-                            )
-                        )
-                        nested_must_not_part.append(
-                            nested_keyvalue_pair_query_template.substitute(
-                                nested=case_sensitive_wildcard_value_condition_template.substitute(  # noqa
+                            nested_query_template_must_must_not.substitute(
+                                must_not_part=case_sensitive_wildcard_value_condition_template.substitute(  # noqa
                                     wild_card_value=value
-                                )
+                                ),
+                                must_part=case_sensitive_must_name_condition_template.substitute(  # noqa
+                                    name=key
+                                ),
                             )
                         )
+
                     else:
                         nested_must_part.append(
-                            nested_keyvalue_pair_query_template.substitute(
-                                nested=case_insensitive_must_name_condition_template.substitute(  # noqa
-                                    name=key
-                                )
-                            )
-                        )
-                        nested_must_not_part.append(
-                            nested_keyvalue_pair_query_template.substitute(
-                                nested=case_insensitive_wildcard_value_condition_template.substitute(  # noqa
+                            nested_query_template_must_must_not.substitute(
+                                must_not_part=case_insensitive_wildcard_value_condition_template.substitute(  # noqa
                                     wild_card_value=value
-                                )
+                                ),
+                                must_part=case_insensitive_must_name_condition_template.substitute(  # noqa
+                                    name=key
+                                ),
                             )
                         )
 
                 else:
                     if case_sensitive:
                         nested_must_part.append(
-                            nested_keyvalue_pair_query_template.substitute(
-                                nested=case_sensitive_must_name_condition_template.substitute(  # noqa
-                                    name=key
-                                )
-                            )
-                        )
-                        nested_must_not_part.append(
-                            nested_keyvalue_pair_query_template.substitute(
-                                nested=case_sensitive_must_value_condition_template.substitute(  # noqa
+                            nested_query_template_must_must_not.substitute(
+                                must_not_part=case_sensitive_must_value_condition_template.substitute(  # noqa
                                     value=value
-                                )
+                                ),
+                                must_part=case_sensitive_must_name_condition_template.substitute(  # noqa
+                                    name=key
+                                ),
                             )
                         )
+
                     else:
                         nested_must_part.append(
-                            nested_keyvalue_pair_query_template.substitute(
-                                nested=case_insensitive_must_name_condition_template.substitute(  # noqa
-                                    name=key
-                                )
-                            )
-                        )
-                        nested_must_not_part.append(
-                            nested_keyvalue_pair_query_template.substitute(
-                                nested=case_insensitive_must_value_condition_template.substitute(  # noqa
+                            nested_query_template_must_must_not.substitute(
+                                must_not_part=case_insensitive_must_value_condition_template.substitute(  # noqa
                                     value=value
-                                )
+                                ),
+                                must_part=case_insensitive_must_name_condition_template.substitute(  # noqa
+                                    name=key
+                                ),
                             )
                         )
 
@@ -702,7 +684,6 @@ def elasticsearch_query_builder(
                     ff = nested_query_template_must_not.substitute(must_not_value=ss)
                     should_part_list_or.append(ff)
     all_terms = ""
-
     for should_part_list_ in all_should_part_list:
         if isinstance(should_part_list_, dict):
             should_part_list = should_part_list_.get("main")

--- a/omero_search_engine/api/v1/resources/utils.py
+++ b/omero_search_engine/api/v1/resources/utils.py
@@ -745,12 +745,94 @@ def search_index_scrol(index_name, query):
     return results
 
 
+def get_bookmark(pagination_dict):
+    """
+    get book mark from the pagination section
+    if the the request does not contain bookmark
+    """
+    bookmark = None
+    if pagination_dict:
+        next_page = pagination_dict["next_page"]
+        bookmark = None
+        for page_rcd in pagination_dict["page_records"]:
+            if page_rcd["page"] == next_page:
+                bookmark = page_rcd["bookmark"]
+                break
+    return bookmark
+
+
+def get_pagination(total_pages, next_bookmark, pagination_dict):
+    """
+    This keeps track of pages, it can be used to track and lood pages (next by default)
+
+    {
+       "current_page":4,
+       "next_page":5,
+       "page_records":[
+          {
+             "bookmark":[
+                304586
+             ],
+             "page":2
+          },
+          {
+             "bookmark":[
+                643303
+             ],
+             "page":3
+          },
+          {
+             "bookmark":[
+                1362671
+             ],
+             "page":4
+          },
+          {
+             "bookmark":[
+                1459210
+             ],
+             "page":5
+          }
+       ],
+       "total_pages":13
+        }
+    """
+    if not pagination_dict:
+        pagination_dict = {}
+        pagination_dict["total_pages"] = total_pages
+        page_rcds = []
+        pagination_dict["page_records"] = page_rcds
+        pagination_dict["current_page"] = 1
+        if total_pages > 1:
+            pagination_dict["next_page"] = 2
+        else:
+            pagination_dict["next_page"] = None
+        page_rcds.append({"page": 2, "bookmark": next_bookmark})
+        return pagination_dict
+    pagination_dict["current_page"] = pagination_dict["next_page"]
+    if pagination_dict["current_page"] == total_pages:
+        pagination_dict["next_page"] = None
+        return pagination_dict
+    pagination_dict["next_page"] = pagination_dict["next_page"] + 1
+    if not get_bookmark(pagination_dict):
+        next_page_record = {
+            "page": pagination_dict["current_page"] + 1,
+            "bookmark": next_bookmark,
+        }
+        page_records = pagination_dict.get("page_records")
+        page_records.append(next_page_record)
+    return pagination_dict
+
+
 def search_index_using_search_after(
-    e_index, query, page, bookmark_, return_containers, ret_type=None
+    e_index, query, bookmark_, pagination_dict, return_containers, ret_type=None
 ):
     returned_results = []
-    if not page:
-        page = 1
+    if bookmark_ and not pagination_dict:
+        add_paination = False
+    else:
+        add_paination = True
+
     es = search_omero_app.config.get("es_connector")
     if return_containers:
         res = es.search(index=e_index, body=query)
@@ -778,6 +860,8 @@ def search_index_using_search_after(
     no_of_pages = (int)(size / page_size) + add_to_page
     search_omero_app.logger.info("No of pages: %s" % no_of_pages)
     query["sort"] = [{"id": "asc"}]
+    if not bookmark_ and pagination_dict:
+        bookmark_ = get_bookmark(pagination_dict)
     if not bookmark_:
         result = es.search(index=e_index, body=query)
         if len(result["hits"]["hits"]) == 0:
@@ -798,14 +882,16 @@ def search_index_using_search_after(
             search_omero_app.logger.info("No result is found")
             return returned_results
         bookmark = [res["hits"]["hits"][-1]["sort"][0]]
-        page += 1
-    return {
+    results_dict = {
         "results": returned_results,
         "total_pages": no_of_pages,
         "bookmark": bookmark,
         "size": size,
-        "page": page,
     }
+    if add_paination:
+        pagination_dict = get_pagination(no_of_pages, bookmark, pagination_dict)
+        results_dict["pagination"] = pagination_dict
+    return results_dict
 
 
 def handle_query(table_, query):
@@ -822,8 +908,8 @@ def search_resource_annotation(
     table_,
     query,
     raw_elasticsearch_query=None,
-    page=None,
     bookmark=None,
+    pagination_dict=None,
     return_containers=False,
 ):
     """
@@ -887,21 +973,26 @@ def search_resource_annotation(
             )
             query["_source"] = {"includes": [""]}
             res = search_index_using_search_after(
-                res_index, query, page, bookmark, return_containers, "project"
+                res_index,
+                query,
+                bookmark,
+                pagination_dict,
+                return_containers,
+                "project",
             )
             query["aggs"] = json.loads(
                 count_attr_template.substitute(field="screen_name.keyvalue")
             )
 
             res_2 = search_index_using_search_after(
-                res_index, query, page, bookmark, return_containers, "screen"
+                res_index, query, bookmark, pagination_dict, return_containers, "screen"
             )
             # Combines the containers results
             studies = res + res_2
             res = {"results": studies}
         else:
             res = search_index_using_search_after(
-                res_index, query, page, bookmark, return_containers
+                res_index, query, bookmark, pagination_dict, return_containers
             )
         notice = ""
         end_time = time.time()

--- a/omero_search_engine/api/v1/resources/utils.py
+++ b/omero_search_engine/api/v1/resources/utils.py
@@ -304,7 +304,7 @@ def elasticsearch_query_builder(
                         value_ = filter["value"]
                     else:
                         # in case of providing it with single query, the values should
-                        # be provided as a string seprated the array items by ','
+                        # be provided as a string separated the array items by ','
                         value_ = filter["value"].split(",")
                     value = [val.strip() for val in value_]
                     value = json.dumps(value)

--- a/omero_search_engine/api/v1/resources/utils.py
+++ b/omero_search_engine/api/v1/resources/utils.py
@@ -299,7 +299,7 @@ def elasticsearch_query_builder(
             try:
                 key = filter["name"].strip()
                 operator = filter["operator"].strip()
-                if operator == "in":
+                if operator == "in" or operator == "not_in":
                     if isinstance(filter["value"], list):
                         value_ = filter["value"]
                     else:
@@ -381,6 +381,41 @@ def elasticsearch_query_builder(
                         nested=",".join(_nested_must_part)
                     )
                 )
+
+            if operator == "not_in":
+                if case_sensitive:
+                    nested_must_not_part.append(
+                        nested_keyvalue_pair_query_template.substitute(
+                            nested=case_sensitive_must_in_value_condition_template.substitute(  # noqa
+                                value=value
+                            )
+                        )
+                    )
+
+                    nested_must_part.append(
+                        nested_keyvalue_pair_query_template.substitute(
+                            nested=case_sensitive_must_name_condition_template.substitute(  # noqa
+                                name=key
+                            )
+                        )
+                    )  # noqa
+
+                else:
+                    nested_must_not_part.append(
+                        nested_keyvalue_pair_query_template.substitute(
+                            nested=case_insensitive_must_in_value_condition_template.substitute(  # noqa
+                                value=value
+                            )
+                        )
+                    )
+
+                    nested_must_part.append(
+                        nested_keyvalue_pair_query_template.substitute(
+                            nested=case_insensitive_must_name_condition_template.substitute(  # noqa
+                                name=key
+                            )
+                        )
+                    )  # noqa
 
             if operator == "contains":
                 value = "*{value}*".format(value=adjust_value(value))

--- a/omero_search_engine/api/v1/resources/utils.py
+++ b/omero_search_engine/api/v1/resources/utils.py
@@ -32,6 +32,18 @@ mm = main_dir.replace("omero_search_engine/api/v2/resources", "")
 sys.path.append(mm)
 
 
+def adjust_value(value):
+    """
+    Adjust the value to search terms which includes * or ?
+    and support search special characters
+    """
+    if value:
+        value = value.strip().strip().lower()
+        value = value.translate({ord(c): "\\\\%s" % c for c in "*?&"})
+        value = value.translate({ord(c): "\\%s" % c for c in '"'})
+    return value
+
+
 def get_resource_annotation_table(resource_table):
     """
     return the related annotation for the resources table
@@ -314,7 +326,7 @@ def elasticsearch_query_builder(
                     )
                 )
             if operator == "contains":
-                value = "*{value}*".format(value=value)
+                value = "*{value}*".format(value=adjust_value(value))
                 # _nested_must_part.append(must_name_condition_template.substitute(name=key)) # noqa
                 if case_sensitive:
                     _nested_must_part.append(
@@ -348,7 +360,7 @@ def elasticsearch_query_builder(
             elif operator in ["not_equals", "not_contains"]:
                 # nested_must_part.append(nested_keyvalue_pair_query_template.substitute(nested=must_name_condition_template.substitute(name=key)))
                 if operator == "not_contains":
-                    value = "*{value}*".format(value=value)
+                    value = "*{value}*".format(value=adjust_value(value))
                     if case_sensitive:
                         nested_must_part.append(
                             nested_keyvalue_pair_query_template.substitute(

--- a/omero_search_engine/cache_functions/elasticsearch/elasticsearch_templates.py
+++ b/omero_search_engine/cache_functions/elasticsearch/elasticsearch_templates.py
@@ -39,6 +39,10 @@ non_image_template = {
                 "type": "text",
                 "fields": {"keyvalue": {"type": "keyword"}},
             },  # noqa
+            "description": {
+                "type": "text",
+                "fields": {"keyvalue": {"type": "keyword"}},
+            },  # noqa
             "owner_id": {"type": "long"},
             "group_id": {"type": "long"},
             "permissions": {"type": "long"},
@@ -101,6 +105,10 @@ image_template = {
             "well_id": {"type": "long"},
             "wellsample_id": {"type": "long"},
             "name": {
+                "type": "text",
+                "fields": {"keyvalue": {"type": "keyword"}},
+            },  # noqa
+            "description": {
                 "type": "text",
                 "fields": {"keyvalue": {"type": "keyword"}},
             },  # noqa

--- a/omero_search_engine/cache_functions/elasticsearch/sql_to_csv.py
+++ b/omero_search_engine/cache_functions/elasticsearch/sql_to_csv.py
@@ -25,7 +25,7 @@ from string import Template
 
 image_sql = Template(
     """
-select image.id, image.owner_id, image.experiment, image.group_id,
+select image.id, image.description, image.owner_id, image.experiment, image.group_id,
 image.name as name, annotation_mapvalue.name as mapvalue_name,
 annotation_mapvalue.value as mapvalue_value,
 annotation_mapvalue.index as mapvalue_index,
@@ -64,7 +64,7 @@ images_sql_to_csv = (
 
 plate_sql = Template(
     """
-select plate.id, plate.owner_id, plate.group_id,
+select plate.id, plate.owner_id, plate.group_id,plate.description,
 plate.name as name, annotation_mapvalue.name as mapvalue_name,
 annotation_mapvalue.value as mapvalue_value,
 annotation_mapvalue.index as mapvalue_index from plate
@@ -84,7 +84,7 @@ plate_sql_to_csv = (
 
 project_sql = Template(
     """
-select project.id, project.owner_id, project.group_id,
+select project.id, project.owner_id, project.group_id, project.description,
 project.name as name, annotation_mapvalue.name as mapvalue_name,
 annotation_mapvalue.value as mapvalue_value,
 annotation_mapvalue.index as mapvalue_index
@@ -106,7 +106,8 @@ WITH CSV HEADER""".format(
 
 screen_sql = Template(
     """
-select screen.id, screen.owner_id, screen.group_id,  screen.name as name,
+select screen.id, screen.owner_id, screen.group_id,
+screen.name as name,screen.description,
 annotation_mapvalue.name as mapvalue_name,
 annotation_mapvalue.value as mapvalue_value,
 annotation_mapvalue.index as mapvalue_index from screen

--- a/omero_search_engine/cache_functions/elasticsearch/transform_data.py
+++ b/omero_search_engine/cache_functions/elasticsearch/transform_data.py
@@ -177,6 +177,7 @@ def prepare_images_data(data, doc_type):
         "experiment",
         "group_id",
         "name",
+        "description",
         "mapvalue_name",
         "mapvalue_value",
         "project_name",
@@ -233,6 +234,7 @@ def prepare_data(data, doc_type):
         "owner_id",
         "group_id",
         "name",
+        "description",
         "mapvalue_name",
         "mapvalue_value",
     ]
@@ -348,6 +350,7 @@ def insert_resource_data(folder, resource, from_json):
             "experiment",
             "group_id",
             "name",
+            "description",
             "mapvalue_name",
             "mapvalue_value",
             "mapvalue_index",
@@ -379,6 +382,7 @@ def insert_resource_data(folder, resource, from_json):
                 "owner_id",
                 "group_id",
                 "name",
+                "description",
                 "mapvalue_name",
                 "mapvalue_value",
                 "mapvalue_index",
@@ -560,14 +564,30 @@ def insert_resource_data_from_df(df, resource, lock=None):
 def insert_project_data(folder, project_file):
     file_name = folder + "\\" + project_file
     es_index = "project_keyvalue_pair_metadata"
-    cols = ["id", "owner_id", "group_id", "name", "mapvalue_name", "mapvalue_value"]
+    cols = [
+        "id",
+        "owner_id",
+        "group_id",
+        "name",
+        "description",
+        "mapvalue_name",
+        "mapvalue_value",
+    ]
     handle_file(file_name, es_index, cols)
 
 
 def insert_screen_data(folder, screen_file):
     file_name = folder + "\\" + screen_file
     es_index = "screen_keyvalue_pair_metadata"
-    cols = ["id", "owner_id", "group_id", "name", "mapvalue_name", "mapvalue_value"]
+    cols = [
+        "id",
+        "owner_id",
+        "group_id",
+        "name",
+        "description",
+        "mapvalue_name",
+        "mapvalue_value",
+    ]
     handle_file(file_name, es_index, cols)
 
 
@@ -581,7 +601,15 @@ def insert_well_data(folder, well_file):
 def insert_plate_data(folder, plate_file):
     file_name = folder + "\\" + plate_file
     es_index = "plate_keyvalue_pair_metadata"
-    cols = ["id", "owner_id", "group_id", "name", "mapvalue_name", "mapvalue_value"]
+    cols = [
+        "id",
+        "owner_id",
+        "group_id",
+        "name",
+        "description",
+        "mapvalue_name",
+        "mapvalue_value",
+    ]
     handle_file(file_name, es_index, cols)
 
 

--- a/omero_search_engine/validation/psql_templates.py
+++ b/omero_search_engine/validation/psql_templates.py
@@ -49,7 +49,7 @@ inner join imageannotationlink on image.id =imageannotationlink.parent
 inner join annotation_mapvalue on
 annotation_mapvalue.annotation_id=imageannotationlink.child
 where lower(annotation_mapvalue.name)='$name' and
-lower(annotation_mapvalue.value)='$value'"""
+lower(annotation_mapvalue.value)=lower('$value')"""
 )
 
 # Get number of images which satisfy project key-value query
@@ -64,8 +64,8 @@ inner join projectannotationlink
 on project.id =projectannotationlink.parent
 inner join annotation_mapvalue
 on annotation_mapvalue.annotation_id=projectannotationlink.child
-where lower(annotation_mapvalue.name)='$name'
-and lower(annotation_mapvalue.value)='$value'"""
+where lower(annotation_mapvalue.name)=lower('$name')
+and lower(annotation_mapvalue.value)=lower('$value')"""
 )
 
 # Get the  number of images using "in"
@@ -94,7 +94,7 @@ on screen.id =screenannotationlink.parent
 inner join annotation_mapvalue
 on annotation_mapvalue.annotation_id=screenannotationlink.child
 where lower(annotation_mapvalue.name)='$name'
-and lower(annotation_mapvalue.value)='$value'"""
+and lower(annotation_mapvalue.value)=lower('$value')"""
 )
 
 
@@ -117,7 +117,7 @@ inner join datasetimagelink on datasetimagelink.child=image.id
 inner join dataset on datasetimagelink.parent=dataset.id
 inner join projectdatasetlink on dataset.id=projectdatasetlink.child
 inner join project on project.id=projectdatasetlink.parent
-where project.name='$name'"""
+where lower(project.name)=lower('$name')"""
 )
 
 # get images in a screen using id
@@ -141,10 +141,40 @@ inner join well on wellsample.well= well.id
 inner join plate on well.plate=plate.id
 inner join screenplatelink on plate.id=screenplatelink.child
 inner join screen on screen.id=screenplatelink.parent
-where screen.name='$name'"""
+where lower(screen.name)=lower('$name')"""
 )
 
 # get resource id using its name
 res_by_name = Template("""select id from $resource where name $name""")
 
 # idr0015-colin-taraoceans/screenA
+
+projects_count = Template(
+    """
+select DISTINCT project.name from image
+inner join imageannotationlink on image.id=imageannotationlink.parent
+inner join annotation_mapvalue on
+annotation_mapvalue.annotation_id=imageannotationlink.child
+inner join datasetimagelink on datasetimagelink.child=image.id
+inner join dataset on datasetimagelink.parent=dataset.id
+inner join projectdatasetlink on dataset.id=projectdatasetlink.child
+inner join project on project.id=projectdatasetlink.parent
+where lower(annotation_mapvalue.name)=lower('$key')
+and lower(annotation_mapvalue.value) =lower('$value')
+"""
+)
+
+screens_count = Template(
+    """
+select DISTINCT screen.name from image
+inner join imageannotationlink on image.id = imageannotationlink.parent
+inner join annotation_mapvalue on
+annotation_mapvalue.annotation_id=imageannotationlink.child
+inner join wellsample on wellsample.image=image.id
+inner join well on wellsample.well= well.id
+inner join plate on well.plate=plate.id
+inner join screenplatelink on plate.id=screenplatelink.child
+inner join screen on screen.id=screenplatelink.parent
+where lower(annotation_mapvalue.name)=lower('$key')
+and  lower(annotation_mapvalue.value) =lower('$value')"""
+)

--- a/omero_search_engine/validation/psql_templates.py
+++ b/omero_search_engine/validation/psql_templates.py
@@ -50,7 +50,6 @@ inner join annotation_mapvalue on
 annotation_mapvalue.annotation_id=imageannotationlink.child
 where lower(annotation_mapvalue.name)='$name' and
 lower(annotation_mapvalue.value)$operator lower('$value')"""
-
 )
 
 # Get number of images which satisfy project key-value query
@@ -67,7 +66,6 @@ inner join annotation_mapvalue
 on annotation_mapvalue.annotation_id=projectannotationlink.child
 where lower(annotation_mapvalue.name)=lower('$name')
 and lower(annotation_mapvalue.value)$operator lower('$value')"""
-
 )
 
 # Get the  number of images using "in"
@@ -120,7 +118,6 @@ inner join dataset on datasetimagelink.parent=dataset.id
 inner join projectdatasetlink on dataset.id=projectdatasetlink.child
 inner join project on project.id=projectdatasetlink.parent
 where lower (project.name) $operator lower ('$name')"""
-
 )
 
 # get images in a screen using id

--- a/omero_search_engine/validation/psql_templates.py
+++ b/omero_search_engine/validation/psql_templates.py
@@ -49,7 +49,8 @@ inner join imageannotationlink on image.id =imageannotationlink.parent
 inner join annotation_mapvalue on
 annotation_mapvalue.annotation_id=imageannotationlink.child
 where lower(annotation_mapvalue.name)='$name' and
-lower(annotation_mapvalue.value)=lower('$value')"""
+lower(annotation_mapvalue.value)$operator lower('$value')"""
+
 )
 
 # Get number of images which satisfy project key-value query
@@ -65,11 +66,12 @@ on project.id =projectannotationlink.parent
 inner join annotation_mapvalue
 on annotation_mapvalue.annotation_id=projectannotationlink.child
 where lower(annotation_mapvalue.name)=lower('$name')
-and lower(annotation_mapvalue.value)=lower('$value')"""
+and lower(annotation_mapvalue.value)$operator lower('$value')"""
+
 )
 
 # Get the  number of images using "in"
-query_image_or = Template(
+query_image_in = Template(
     """
 Select DISTINCT image.id from image
 inner join imageannotationlink
@@ -77,7 +79,7 @@ on image.id =imageannotationlink.parent
 inner join annotation_mapvalue
 on annotation_mapvalue.annotation_id=imageannotationlink.child
 where lower(annotation_mapvalue.name) in ($names)
-and lower(annotation_mapvalue.value) in ($values)"""
+and lower(annotation_mapvalue.value) $operator ($values)"""
 )
 
 # Get the images which satisfy screen key-value query
@@ -93,8 +95,8 @@ inner join screenannotationlink
 on screen.id =screenannotationlink.parent
 inner join annotation_mapvalue
 on annotation_mapvalue.annotation_id=screenannotationlink.child
-where lower(annotation_mapvalue.name)='$name'
-and lower(annotation_mapvalue.value)=lower('$value')"""
+where lower(annotation_mapvalue.name)= lower('$name')
+and lower(annotation_mapvalue.value)$operator lower('$value')"""
 )
 
 
@@ -117,7 +119,8 @@ inner join datasetimagelink on datasetimagelink.child=image.id
 inner join dataset on datasetimagelink.parent=dataset.id
 inner join projectdatasetlink on dataset.id=projectdatasetlink.child
 inner join project on project.id=projectdatasetlink.parent
-where lower(project.name)=lower('$name')"""
+where lower (project.name) $operator lower ('$name')"""
+
 )
 
 # get images in a screen using id
@@ -141,7 +144,7 @@ inner join well on wellsample.well= well.id
 inner join plate on well.plate=plate.id
 inner join screenplatelink on plate.id=screenplatelink.child
 inner join screen on screen.id=screenplatelink.parent
-where lower(screen.name)=lower('$name')"""
+where lower(screen.name)$operator lower('$name')"""
 )
 
 # get resource id using its name

--- a/omero_search_engine/validation/results_validator.py
+++ b/omero_search_engine/validation/results_validator.py
@@ -227,14 +227,21 @@ class Validator(object):
                     item["id"]
                     for item in searchengine_results["results"]["results"]  # noqa
                 ]
+                idsp = [
+                    item["id"]
+                    for item in searchengine_results["results"]["results"]  # noqa
+                ]
             else:
                 size = 0
                 ids = []
+                idsp = []
 
                 # get all the results if the total number is bigger
                 # than the page size
             if size >= search_omero_app.config["PAGE_SIZE"] and self.deep_check:
                 bookmark = searchengine_results["results"]["bookmark"]
+                pagination_dict = searchengine_results["results"]["pagination"]
+                # check getting the results using bookmark
                 while len(ids) < size:
                     search_omero_app.logger.info(
                         "Received %s/%s" % (len(ids), size)
@@ -249,11 +256,38 @@ class Validator(object):
                     ]
                     ids = ids + ids_
                     bookmark = searchengine_results_["results"]["bookmark"]
-            self.searchengine_results = {"size": size, "ids": ids}
+                # check the results using pagination
+                query_data_ = {"query_details": query, "bookmark": None}
+                next_page = pagination_dict.get("next_page")
+                while next_page:
+                    query_data_ = {
+                        "query_details": query,
+                        "pagination": pagination_dict,
+                    }
+                    searchengine_results_ = determine_search_results_(
+                        query_data_
+                    )  # noqa
+                    ids_ = [
+                        item["id"]
+                        for item in searchengine_results_["results"]["results"]
+                    ]
+                    idsp = idsp + ids_
+                    pagination_dict = searchengine_results["results"]["pagination"]
+                    next_page = pagination_dict.get("next_page")
+                if len(ids) != len(idsp):
+                    search_omero_app.logger.info(
+                        "The results using bookmark (%s)  and the "
+                        "results using pagination (%s) are not equal"
+                        % (len(ids), len(idsp))
+                    )
+
+            self.searchengine_results = {"size": size, "ids": ids, "idsp": idsp}
+
             search_omero_app.logger.info(
                 "no of received results from searchengine  : %s"
                 % self.searchengine_results.get("size")
             )
+
         else:
             search_omero_app.logger.info("The query is not valid")
 
@@ -289,6 +323,8 @@ class Validator(object):
             None,
             return_containers=True,
         )
+        print(search_engine_results["results"])
+        print("======================")
         if search_engine_results["results"].get("results"):
             for item in search_engine_results["results"].get("results"):
                 if item["type"] == "screen":
@@ -328,7 +364,7 @@ class Validator(object):
             no_results_postgresql = len(screens_results_idr) + len(projects_results_idr)
             if no_results_postgresql == no_results_searchengine:
                 mes = (
-                    "The number of the results from PostgreSQL "
+                    "The number of the results (containers) from PostgreSQL "
                     "and the Searchengine (%s) are equal" % no_results_postgresql
                 )
                 mess.append(mes)
@@ -363,19 +399,25 @@ class Validator(object):
             ids_in = True
             is_it_repated = []
             serach_ids = [id for id in self.searchengine_results.get("ids")]
+            serach_idsp = [id for id in self.searchengine_results.get("idsp")]
             if self.deep_check:
                 if sorted(serach_ids) != sorted(self.postgres_results):
                     ids_in = False
+                if sorted(serach_idsp) != sorted(serach_ids):
+                    ids_in = False
             else:
-                for id in serach_ids:
-                    if id in is_it_repated:
-                        ids_in = False
-                        break
-                    else:
-                        is_it_repated.append(id)
-                    if id not in self.postgres_results:
-                        ids_in = False
-                        break
+                if sorted(serach_idsp) != sorted(serach_ids):
+                    ids_in = False
+                else:
+                    for id in serach_ids:
+                        if id in is_it_repated:
+                            ids_in = False
+                            break
+                        else:
+                            is_it_repated.append(id)
+                        if id not in self.postgres_results:
+                            ids_in = False
+                            break
             if ids_in:
                 search_omero_app.logger.info(
                     "No of the retuned results are similar ..."
@@ -389,12 +431,32 @@ class Validator(object):
             searchengine_no = self.searchengine_results.get("size")
         else:
             searchengine_no = self.searchengine_results
-        return (
-            "not equal, database no of the results from server is: %s and\
-             the number of results from searchengine is %s?,\
-             \ndatabase server query time= %s, searchengine query time= %s"
-            % (len(self.postgres_results), searchengine_no, sql_time, searchengine_time)
-        )
+        if not self.deep_check:
+            return (
+                "not equal, database no of the results from server is: %s and\
+                 the number of results from searchengine (bookmark) is %s?,\
+                 \ndatabase server query time= %s, searchengine query time= %s"
+                % (
+                    len(self.postgres_results),
+                    searchengine_no,
+                    sql_time,
+                    searchengine_time,
+                )
+            )
+        else:
+            return (
+                "not equal, database no of the results from server is: %s and\
+                     the number of results from searchengine (bookmark) is %s?,\
+                    the number of results from searchengine (pagination) is %s?,\
+                     \ndatabase server query time= %s, searchengine query time= %s"
+                % (
+                    len(self.postgres_results),
+                    searchengine_no,
+                    len(serach_idsp),
+                    sql_time,
+                    searchengine_time,
+                )
+            )
 
 
 def validate_queries(json_file, deep_check):

--- a/omero_search_engine/validation/results_validator.py
+++ b/omero_search_engine/validation/results_validator.py
@@ -30,9 +30,10 @@ from omero_search_engine.validation.psql_templates import (
     query_images_screen_key_value,
     query_images_in_project_name,
     query_images_screen_name,
-    query_image_or,
+    query_image_in,
     screens_count,
     projects_count,
+
 )
 import os
 
@@ -42,7 +43,9 @@ query_methods = {
     "screen": query_images_screen_key_value,
     "project_name": query_images_in_project_name,
     "screen_name": query_images_screen_name,
-    "query_image_or": query_image_or,
+    "query_image_or": query_image_in,
+    "in_clause": query_image_in,
+    "not_in_clause": query_image_in,
     "screens_count": screens_count,
     "projects_count": projects_count,
 }
@@ -69,6 +72,14 @@ class Validator(object):
         self.sql_statement = query_methods[resource]
         self.searchengine_results = {}
 
+    def set_in_query(self, clauses, resource="image", type="in_clause"):
+        """
+        in list query
+        """
+        self.type = type
+        self.clauses = clauses
+        self.resource = resource
+
     def set_complex_query(self, name, clauses, resource="image", type="complex"):
         """
         complex query
@@ -81,6 +92,27 @@ class Validator(object):
         self.postgres_results = []
         self.searchengine_results = {}
 
+    def get_in_sql(self, clauses, name="in_clause"):
+        names = "'%s'" % clauses[0].lower()
+        cases = [c.lower() for c in clauses[1]]
+        values = "'" + "','".join(cases) + "'"
+        if name == "in_clause":
+            sql = query_methods[name].substitute(
+                names=names, values=values, operator="in"
+            )
+        elif name == "not_in_clause":
+            sql = query_methods[name].substitute(
+                names=names, values=values, operator="not in"
+            )
+        # sql = query_methods[name].substitute(names=names, values=values)
+        conn = search_omero_app.config["database_connector"]
+        postgres_results = conn.execute_query(sql)
+        results = [item["id"] for item in postgres_results]
+        search_omero_app.logger.info(
+            "results for or received %s" % len(results)
+        )  # noqa
+        return results
+
     def get_or_sql(self, clauses, name="query_image_or"):
         names = ""
         values = ""
@@ -91,7 +123,8 @@ class Validator(object):
             else:
                 names = "'%s'" % claus[0].lower()
                 values = "'%s'" % claus[1].lower()
-        sql = query_methods[name].substitute(names=names, values=values)
+        # sql = query_methods[name].substitute(names=names, values=values)
+        sql = query_methods[name].substitute(names=names, values=values, operator="in")
         conn = search_omero_app.config["database_connector"]
         postgres_results = conn.execute_query(sql)
         results = [item["id"] for item in postgres_results]
@@ -105,7 +138,10 @@ class Validator(object):
         co = 0
         for claus in clauses:
             sql = query_methods["image"].substitute(
-                name=claus[0].lower(), value=claus[1].lower()
+                # toz
+                operator="=",
+                name=claus[0].lower(),
+                value=claus[1].lower(),
             )
             conn = search_omero_app.config["database_connector"]
             postgres_results = conn.execute_query(sql)
@@ -120,12 +156,18 @@ class Validator(object):
             co += 1
         return results
 
-    def get_results_postgres(self):
+    def get_results_postgres(self, operator=None):
         """
         Query the postgresql
         """
         search_omero_app.logger.info("Getting results from postgres")
-        if self.type == "complex":
+        if self.type == "in_clause":
+            self.postgres_results = self.get_in_sql(self.clauses)
+            return
+        elif self.type == "not_in_clause":
+            self.postgres_results = self.get_in_sql(self.clauses, self.type)
+            return
+        elif self.type == "complex":
             if self.name == "query_image_or":
                 self.postgres_results = self.get_or_sql(self.clauses)
             elif self.name == "query_image_and":
@@ -141,12 +183,19 @@ class Validator(object):
                 )
             return
         else:
+            if not operator or operator =="equals":
+                operator="="
+            else:
+                operator="!="
             if self.name != "name":
                 sql = self.sql_statement.substitute(
-                    name=self.name.lower(), value=self.value.lower()
+                    # toz
+                    operator=operator,
+                    name=self.name.lower(),
+                    value=self.value.lower(),
                 )
             else:
-                sql = self.sql_statement.substitute(name=self.value)
+                sql = self.sql_statement.substitute(name=self.value, operator=operator)
         # search_omero_app.logger.info ("sql: %s"%sql)
         conn = search_omero_app.config["database_connector"]
         postgres_results = conn.execute_query(sql)
@@ -155,11 +204,35 @@ class Validator(object):
             "results received %s" % len(self.postgres_results)
         )  # noqa
 
-    def get_results_searchengine(self):
+    def get_results_searchengine(self, operator=None):
         """
         Query the results from the serachengine
         """
-        if self.type == "complex":
+        if self.type == "in_clause":
+            filters = []
+            filters.append(
+                {
+                    "name": self.clauses[0],
+                    "value": self.clauses[1],
+                    "operator": "in",
+                    "resource": self.resource,
+                }
+            )
+            query = {"and_filters": filters, "or_filters": []}
+
+        elif self.type == "not_in_clause":
+            filters = []
+            filters.append(
+                {
+                    "name": self.clauses[0],
+                    "value": self.clauses[1],
+                    "operator": "not_in",
+                    "resource": self.resource,
+                }
+            )
+            query = {"and_filters": filters, "or_filters": []}
+
+        elif self.type == "complex":
             filters = []
             if self.name != "query_image_and_or":
                 for claus in self.clauses:
@@ -196,12 +269,14 @@ class Validator(object):
                         )
 
         else:
+            if not operator:
+                operator="equals"
             if self.name != "name":
                 and_filters = [
                     {
                         "name": self.name.lower(),
                         "value": self.value.lower(),
-                        "operator": "equals",
+                        "operator": operator,
                         "resource": self.resource,
                     }
                 ]
@@ -211,7 +286,7 @@ class Validator(object):
                         "name": "Name (IDR number)",
                         "value": self.value,
                         "resource": "project",
-                        "operator": "equals",
+                        "operator": operator,
                     }
                 ]
             query = {"and_filters": and_filters, "or_filters": []}
@@ -291,106 +366,16 @@ class Validator(object):
         else:
             search_omero_app.logger.info("The query is not valid")
 
-    def get_containers_test_cases(self):
-        """
-        Compare the results containers from postgres and the searchengine
-        """
-        mess = []
-        mes = "Checking the results containers for name '%s' and value '%s'" % (
-            self.name,
-            self.value,
-        )
-        mess.append(mes)
-        search_omero_app.logger.info(mes)
-        screens_count_sql = query_methods["screens_count"].substitute(
-            key=self.name, value=self.value
-        )
-        projects_count_sql = query_methods["projects_count"].substitute(
-            key=self.name, value=self.value
-        )
-        conn = search_omero_app.config["database_connector"]
-        screens_results = conn.execute_query(screens_count_sql)
-        projects_results = conn.execute_query(projects_count_sql)
-        screens_results_idr = [item["name"] for item in screens_results]
-        projects_results_idr = [item["name"] for item in projects_results]
-        search_engine_results = simple_search(
-            self.name,
-            self.value,
-            "equals",
-            False,
-            None,
-            self.resource,
-            None,
-            return_containers=True,
-        )
-        print(search_engine_results["results"])
-        print("======================")
-        if search_engine_results["results"].get("results"):
-            for item in search_engine_results["results"].get("results"):
-                if item["type"] == "screen":
-                    if item["name"] in screens_results_idr:
-                        mes = (
-                            "Screen %s is found in the PostgreSQL results"
-                            % item["name"]
-                        )
-                        mess.append(mes)
-                        search_omero_app.logger.info(mes)
-                    else:
-                        mes = (
-                            "Erro, screen %s is not found in the PostgreSQL results"
-                            % item["name"]
-                        )
-                        mess.append(mes)
-                        search_omero_app.logger.info(mes)
 
-                elif item["type"] == "project":
-                    if item["name"] in projects_results_idr:
-                        mes = (
-                            "Project %s is found in the PostgreSQL results"
-                            % item["name"]
-                        )
-                        mess.append(mes)
-                        search_omero_app.logger.info(mes)
-                    else:
-                        mes = (
-                            "Error, project %s is not found in the PostgreSQL results"
-                            % item["name"]
-                        )
-                        mess.append(mes)
-                        search_omero_app.logger.info(mes)
-            no_results_searchengine = len(
-                search_engine_results["results"].get("results")
-            )
-            no_results_postgresql = len(screens_results_idr) + len(projects_results_idr)
-            if no_results_postgresql == no_results_searchengine:
-                mes = (
-                    "The number of the results (containers) from PostgreSQL "
-                    "and the Searchengine (%s) are equal" % no_results_postgresql
-                )
-                mess.append(mes)
-                search_omero_app.logger.info(mes)
-            else:
-                mes = (
-                    "Error, the number of the results from PostgreSQL %s "
-                    "and the Searchengine %s are not equal"
-                    % (no_results_postgresql, no_results_searchengine)
-                )
-                mess.append(mes)
-                search_omero_app.logger.info(mes)
-        else:
-            mes = "No results found in the Searchengine"
-            mess.append(mes)
-            search_omero_app.logger.info(mes)
-        return mess
+    def compare_results(self, operator=None):
 
-    def compare_results(self):
         """
         call the results
         """
         st_time = datetime.now()
-        self.get_results_postgres()
+        self.get_results_postgres(operator)
         st2_time = datetime.now()
-        self.get_results_searchengine()
+        self.get_results_searchengine(operator)
         st3_time = datetime.now()
         sql_time = st2_time - st_time
         searchengine_time = st3_time - st2_time
@@ -431,32 +416,12 @@ class Validator(object):
             searchengine_no = self.searchengine_results.get("size")
         else:
             searchengine_no = self.searchengine_results
-        if not self.deep_check:
-            return (
-                "not equal, database no of the results from server is: %s and\
-                 the number of results from searchengine (bookmark) is %s?,\
-                 \ndatabase server query time= %s, searchengine query time= %s"
-                % (
-                    len(self.postgres_results),
-                    searchengine_no,
-                    sql_time,
-                    searchengine_time,
-                )
-            )
-        else:
-            return (
-                "not equal, database no of the results from server is: %s and\
-                     the number of results from searchengine (bookmark) is %s?,\
-                    the number of results from searchengine (pagination) is %s?,\
-                     \ndatabase server query time= %s, searchengine query time= %s"
-                % (
-                    len(self.postgres_results),
-                    searchengine_no,
-                    len(serach_idsp),
-                    sql_time,
-                    searchengine_time,
-                )
-            )
+        return (
+            "not equal, database no of the results from database server is: %s and\
+             the number of results from searchengine is %s?,\
+             \ndatabase server query time= %s, searchengine query time= %s"
+            % (len(self.postgres_results), searchengine_no, sql_time, searchengine_time)
+        )
 
 
 def validate_queries(json_file, deep_check):
@@ -474,6 +439,7 @@ def validate_queries(json_file, deep_check):
 
     test_cases = test_data.get("test_cases")
     complex_test_cases = test_data.get("complex_test_cases")
+    query_in = test_data.get("query_in")
     messages = []
     from datetime import datetime
 
@@ -483,20 +449,38 @@ def validate_queries(json_file, deep_check):
             name = case[0]
             value = case[1]
             search_omero_app.logger.info(
-                "Testing %s for name: %s, key: %s" % (resource, name, value)
+                "Testing (equals) %s for name: %s, key: %s" % (resource, name, value)
             )
             validator = Validator(deep_check)
             validator.set_simple_query(resource, name, value)
-            if resource == "image":
-                mess = validator.get_containers_test_cases()
-                messages = messages + mess
-
-            res = validator.compare_results()
+            #if resource == "image":
+            #    mess = validator.get_containers_test_cases()
+            #    messages = messages + mess
+            res = validator.compare_results("equals")
             elabsed_time = str(datetime.now() - start_time)
             messages.append(
-                "Results from PostgreSQL and search engine for "
-                "name '%s', value '%s', are: %s"
+
+                "Results form (equals) PostgreSQL and search engine\
+                 for name: %s , value: %s are: %s"
+
                 % (validator.name, validator.value, res)
+            )
+            search_omero_app.logger.info("Total time=%s" % elabsed_time)
+
+            # Not equals
+            start_time = datetime.now()
+            search_omero_app.logger.info(
+                "Testing (not equals) %s for name: %s, key: %s"
+                % (resource, name, value)
+            )
+            not_equls_validator = Validator(deep_check)
+            not_equls_validator.set_simple_query(resource, name, value)
+            res = not_equls_validator.compare_results("not_equals")
+            elabsed_time = str(datetime.now() - start_time)
+            messages.append(
+                "Results (not_equals) form PostgreSQL and search engine\
+                 for name: %s , value: %s are: %s"
+                % (not_equls_validator.name, not_equls_validator.value, res)
             )
             search_omero_app.logger.info("Total time=%s" % elabsed_time)
 
@@ -514,6 +498,42 @@ def validate_queries(json_file, deep_check):
             search_omero_app.logger.info(
                 "Total time=%s" % str(datetime.now() - start_time)
             )
+
+    for resource, cases in query_in.items():
+        for case in cases:
+            start_time = datetime.now()
+            validator_in = Validator(deep_check)
+            validator_in.set_in_query(case, resource)
+            res = validator_in.compare_results()
+            messages.append(
+                "Results for 'in' form PostgreSQL and search engine\
+                for %s name: %s and value in [%s] are %s"
+                % (
+                    validator_in.resource,
+                    validator_in.clauses[0],
+                    ",".join(validator_in.clauses[1]),
+                    res,
+                )
+            )
+            end_in = datetime.now()
+            search_omero_app.logger.info("Total time=%s" % str(end_in - start_time))
+            # test the same but chang the operator to not in
+            search_omero_app.logger.info("Total time=%s" % str(end_in - start_time))
+            validator_not_in = Validator(deep_check)
+            validator_not_in.set_in_query(case, resource, type="not_in_clause")
+            res = validator_not_in.compare_results()
+            messages.append(
+                "Results for 'not in' form PostgreSQL and search engine for %s name: "
+                "%s and value in [%s] are %s"
+                % (
+                    validator_not_in.resource,
+                    validator_not_in.clauses[0],
+                    ",".join(validator_not_in.clauses[1]),
+                    res,
+                )
+            )
+            search_omero_app.logger.info("Total time=%s" % str(datetime.now() - end_in))
+
     search_omero_app.logger.info(
         "############################################## Check Report ##############################################"  # noqa
     )

--- a/run_examples.sh
+++ b/run_examples.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+printf '%s\n' examples/*.py | xargs -n1 python


### PR DESCRIPTION
Adding the support to the `in` search  operator.  In the previous implementation, if the user wants to use it they need to add many `or` conditions, but using `in` will make that one condition.  It is similar to using the `in` operator in the SQL statement. 
It has been deployed in [idr-testing ](https://idr-testing.openmicroscopy.org/searchengine/apidocs/).
It can be used with a single search or complex search.

For example, search `“Gene Symbol” in ["Duoxa2", "Bach2", "Cxcr2", "Mysm1"].`
In the simple search, the user needs to set the operator to be `in `as the default is `equals`, they can put a values list with a `,` separated string. 

`https://idr-testing.openmicroscopy.org/searchengine//api/v1/resources/image/search/?key=Gene Symbol&value=Duoxa2,Bach2,Cxcr2,Mysm1&operator=in`

The following command can be used to test the `in` operator with the complex search

`curl -X POST "https://idr-testing.openmicroscopy.org/searchengine//api/v1/resources/image/searchannotation/" -H "accept: application/json" -H "Content-Type: application/json" -d "{ \"query_details\":{ \"and_filters\":[ { \"name\":\"Gene Symbol\", \"value\":[ \"Duoxa2\", \"Bach2\", \"Cxcr2\", \"Mysm1\" ], \"operator\":\"in\", \"resource\":\"image\" } ] }}"`

