### PR TITLE
Searchvalues endpoint resource fix

### DIFF
--- a/omero_search_engine/api/v1/resources/resource_analyser.py
+++ b/omero_search_engine/api/v1/resources/resource_analyser.py
@@ -442,7 +442,7 @@ def search_value_for_resource(table_, value, es_index="key_value_buckets_informa
             value = value.replace("\\", "\\\\")
         value = "*{value}*".format(value=value)
         query = resource_key_values_buckets_template.substitute(
-            value=value, resource="image"
+            value=value, resource=table_
         )
         res = search_index_for_value(es_index, query)
         return prepare_search_results(res)

--- a/omero_search_engine/api/v1/resources/urls.py
+++ b/omero_search_engine/api/v1/resources/urls.py
@@ -179,6 +179,12 @@ def get_values_using_value(resource_table):
         return jsonify(
             build_error_message("Error: {error}".format(error="No value is provided "))
         )
+    #check if resource_table is vaild
+    if not (get_resource_annotation_table(resource_table)):
+        message= "NO data for table {table}".format(table=resource_table)
+        return jsonify(
+            build_error_message(message)
+    )
     # print (value, resource_table)
     return jsonify(search_value_for_resource(resource_table, value))
 

--- a/omero_search_engine/api/v1/resources/urls.py
+++ b/omero_search_engine/api/v1/resources/urls.py
@@ -179,12 +179,10 @@ def get_values_using_value(resource_table):
         return jsonify(
             build_error_message("Error: {error}".format(error="No value is provided "))
         )
-    #check if resource_table is vaild
+    # check if resource_table is vaild
     if not (get_resource_annotation_table(resource_table)):
-        message= "NO data for table {table}".format(table=resource_table)
-        return jsonify(
-            build_error_message(message)
-    )
+        message = "NO data for table {table}".format(table=resource_table)
+        return jsonify(build_error_message(message))
     # print (value, resource_table)
     return jsonify(search_value_for_resource(resource_table, value))
 

--- a/omero_search_engine/api/v1/resources/urls.py
+++ b/omero_search_engine/api/v1/resources/urls.py
@@ -18,7 +18,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from . import resources
-from flask import request, jsonify
+from flask import request, jsonify, make_response
 import json
 from omero_search_engine.api.v1.resources.utils import (
     search_resource_annotation,
@@ -49,12 +49,12 @@ def search_resource_page(resource_table):
     """
     used to get the next results page
     """
-    if not (get_resource_annotation_table):
-        return jsonify(
-            build_error_message(
-                "No data for table {table}".format(table=resource_table)
-            )
-        )
+    if not (get_resource_annotation_table(resource_table)):
+        resp_message = "No data for table {table}".format(table=resource_table)
+        response = make_response(resp_message, 404)
+        response.mimetype = "text/plain"
+        return response
+
     data = request.data
     if not data:
         return jsonify(
@@ -123,12 +123,12 @@ def search_resource(resource_table):
        or_filters means that the results should satisfy at least one condition inside the filters
     """
 
-    if not (get_resource_annotation_table):
-        return jsonify(
-            build_error_message(
-                "NO data for table {table}".format(table=resource_table)
-            )
-        )
+    if not (get_resource_annotation_table(resource_table)):
+        resp_message = "No data for table {table}".format(table=resource_table)
+        response = make_response(resp_message, 404)
+        response.mimetype = "text/plain"
+        return response
+
     data = request.data
     if not data:
         return jsonify(
@@ -181,8 +181,12 @@ def get_values_using_value(resource_table):
         )
     # check if resource_table is vaild
     if not (get_resource_annotation_table(resource_table)):
-        message = "NO data for table {table}".format(table=resource_table)
-        return jsonify(build_error_message(message))
+        # If the resource does not exist, it will return a 404 with a message.
+        resp_message = "No data for table {table}".format(table=resource_table)
+        response = make_response(resp_message, 404)
+        response.mimetype = "text/plain"
+        return response
+
     # print (value, resource_table)
     return jsonify(search_value_for_resource(resource_table, value))
 
@@ -252,7 +256,10 @@ def get_resource_names_(resource_table):
     Query the available attributes for a specific resource
     """
     if not (get_resource_annotation_table(resource_table)):
-        return "NO data for table {table}".format(table=resource_table)
+        resp_message = "No data for table {table}".format(table=resource_table)
+        response = make_response(resp_message, 404)
+        response.mimetype = "text/plain"
+        return response
 
     names = get_resource_names(resource_table)
     return jsonify(names)


### PR DESCRIPTION
The `image` was the default `resource` if `all` is not used for this endpoint. I have fixed that and added a check for the `resource` name.

@will-moore  Please try that as you have reported this issue in slack.