### PR TITLE
Allow return no of images for each value for a specific key fix issue #11

### DIFF
--- a/omero_search_engine/api/v1/resources/swagger_docs/search_for_any_value.yml
+++ b/omero_search_engine/api/v1/resources/swagger_docs/search_for_any_value.yml
@@ -1,4 +1,5 @@
-Search for a value whose attribute is not known.
+Search for a value whose attribute is not known. if a key (attribute) is submitted, it will search for and obtain the available values for an attribute and part of the value for one or all resources e.g. 'homo' to return all values which contain 'homo' for the provided attribute and resource.
+It returns a JSON string containing the results.
 ---
 tags:
  - Search for any value
@@ -13,6 +14,11 @@ parameters:
     in: query
     type: string
     required: true
+  - name: key
+    description: search term
+    in: query
+    type: string
+    required: false
 definitions:
  data:
     type: object

--- a/omero_search_engine/api/v1/resources/urls.py
+++ b/omero_search_engine/api/v1/resources/urls.py
@@ -30,6 +30,7 @@ from omero_search_engine.api.v1.resources.resource_analyser import (
     get_resource_attribute_values,
     get_resource_names,
     get_key_values_return_contents,
+    query_cashed_bucket_part_value_keys,
 )
 from omero_search_engine.api.v1.resources.utils import get_resource_annotation_table
 from omero_search_engine.api.v1.resources.query_handler import (
@@ -180,7 +181,12 @@ def get_values_using_value(resource_table):
             build_error_message("Error: {error}".format(error="No value is provided "))
         )
     # print (value, resource_table)
-    return jsonify(search_value_for_resource(resource_table, value))
+    key = request.args.get("key")
+    if key:
+        # If the key is provided it will restrict the search to the provided key.
+        return query_cashed_bucket_part_value_keys(key, value, resource_table)
+    else:
+        return jsonify(search_value_for_resource(resource_table, value))
 
 
 @resources.route("/<resource_table>/searchvaluesusingkey/", methods=["GET"])


### PR DESCRIPTION
… of #11

This endpoint returns all the possible keys whose values contain `pdx`.
[http://idr-testing.openmicroscopy.org/searchengine/api/v1/resources/image/searchvalues/?value=pdx 
](http://idr-testing.openmicroscopy.org/searchengine/api/v1/resources/image/searchvalues/?value=pdx 
)
Now, the same endpoint can be used to restrict the search to return the values for a specific key. it is needed to add the key name, e.g.  `gene symbol`

[http://idr-testing.openmicroscopy.org/searchengine/api/v1/resources/image/searchvalues/?value=pdx%20&key=gene%20symbol](http://idr-testing.openmicroscopy.org/searchengine/api/v1/resources/image/searchvalues/?value=pdx%20&key=gene%20symbol)

@will-moore  What do you think? It is deployed in the idr-testing.
