### PR TITLE
Return studies image count and titles

### DIFF
--- a/app_data/test_index_data.json
+++ b/app_data/test_index_data.json
@@ -66,6 +66,10 @@
             "hcc44"
          ],
          [
+            "cell line",
+            "hela"
+         ],
+         [
             "Cell Cycle Phase",
             "anaphase"
          ],

--- a/examples/return_containers_only.py
+++ b/examples/return_containers_only.py
@@ -57,4 +57,7 @@ if returned_results.get("results"):
     if len(returned_results.get("results").get("results")) == 0:
         logging.info("No results is found")
     for item in returned_results.get("results").get("results"):
-        logging.info("%s: %s contains %s images" % (item.get("type"),item.get("name"), item.get("image count")))
+        logging.info(
+            "%s: %s contains %s images"
+            % (item.get("type"), item.get("name"), item.get("image count"))
+        )

--- a/examples/return_containers_only.py
+++ b/examples/return_containers_only.py
@@ -44,7 +44,7 @@ curl -X GET "http://127.0.0.1:5577/api/v1/resources/image/search/?key=Organism&v
 
 page = 0
 ids = []
-logging.info(" Searching for: Organism Homo sapiens")
+logging.info("Searching for: Organism Homo sapiens")
 
 
 url = "%s%s?key=Organism&value=Homo sapiens&return_containers=true" % (
@@ -57,4 +57,4 @@ if returned_results.get("results"):
     if len(returned_results.get("results").get("results")) == 0:
         logging.info("No results is found")
     for item in returned_results.get("results").get("results"):
-        logging.info("Study: %s" % item.get("Name (IDR number)"))
+        logging.info("%s: %s contains %s images" % (item.get("type"),item.get("name"), item.get("image count")))

--- a/omero_search_engine/api/v1/resources/resource_analyser.py
+++ b/omero_search_engine/api/v1/resources/resource_analyser.py
@@ -573,7 +573,7 @@ resource_key_values_buckets_template = Template(
 "must":{"wildcard":{"Value.keyvaluenormalize":"$value"}}}},{
 "bool": {"must": {"match":
 {"resource.keyresource": "$resource"}}}}]}},
-"size": 9999}"""
+"size": 9999, "sort": [{"items_in_the_bucket": "desc"}]}"""
 )
 
 

--- a/omero_search_engine/api/v1/resources/urls.py
+++ b/omero_search_engine/api/v1/resources/urls.py
@@ -260,7 +260,7 @@ def get_resource_names_(resource_table):
     return jsonify(names)
 
 
-@resources.route("/submitquery_returnstudies/", methods=["POST"])
+@resources.route("/submitquery/containers/", methods=["POST"])
 def submit_query_return_containers():
     """
     file: swagger_docs/submitquery_returncontainers.yml

--- a/omero_search_engine/api/v1/resources/utils.py
+++ b/omero_search_engine/api/v1/resources/utils.py
@@ -760,6 +760,7 @@ def search_index_using_search_after(
                     "image count": ek["doc_count"],
                     "title": st,
                     "type": ret_type,
+                    "id": res_res.get("id"),
                 }
             )
 
@@ -934,10 +935,11 @@ def get_studies_titles(idr_name, resource):
         res_index, resource_query, None, None, None
     )
     for item_ in resourse_res["results"]:
+        study_title["id"] = item_["id"]
         for item in item_["key_values"]:
             if item["name"] == "Publication Title" or item["name"] == "Study Title":
                 study_title[item["name"]] = item["value"]
-                if len(study_title) == 2:
+                if len(study_title) == 3:
                     break
 
     return study_title

--- a/omero_search_engine/api/v1/resources/utils.py
+++ b/omero_search_engine/api/v1/resources/utils.py
@@ -747,13 +747,11 @@ def search_index_using_search_after(
             return returned_results
         keys_counts = res["aggregations"]["key_count"]["buckets"]
         idrs = []
-
         for ek in keys_counts:
             idrs.append(ek["key"])
             res_res = get_studies_titles(ek["key"], ret_type)
-
+            res_res["image count"] = ek["doc_count"]
             returned_results.append(res_res)
-
 
         return returned_results
     page_size = search_omero_app.config.get("PAGE_SIZE")
@@ -922,12 +920,10 @@ def get_studies_titles(idr_name, resource):
     resourse_res = search_index_using_search_after(
         res_index, resource_query, None, None, None
     )
-    print (resourse_res)
     for item_ in resourse_res["results"]:
-        print (item_)
         study_title["id"] = item_.get("id")
         study_title["name"] = item_.get("name")
         study_title["type"] = resource
         study_title["description"] = item_.get("description")
-        study_title["key_values"]=item_.get("key_values")
+        study_title["key_values"] = item_.get("key_values")
     return study_title

--- a/omero_search_engine/api/v1/resources/utils.py
+++ b/omero_search_engine/api/v1/resources/utils.py
@@ -925,5 +925,9 @@ def get_studies_titles(idr_name, resource):
         study_title["name"] = item_.get("name")
         study_title["type"] = resource
         study_title["description"] = item_.get("description")
+        for value in item_.get("key_values"):
+            if value.get("name"):
+                value["key"] = value["name"]
+                del value["name"]
         study_title["key_values"] = item_.get("key_values")
     return study_title

--- a/omero_search_engine/cache_functions/elasticsearch/elasticsearch_templates.py
+++ b/omero_search_engine/cache_functions/elasticsearch/elasticsearch_templates.py
@@ -39,6 +39,10 @@ non_image_template = {
                 "type": "text",
                 "fields": {"keyvalue": {"type": "keyword"}},
             },  # noqa
+            "description": {
+                "type": "text",
+                "fields": {"keyvalue": {"type": "keyword"}},
+            },  # noqa
             "owner_id": {"type": "long"},
             "group_id": {"type": "long"},
             "permissions": {"type": "long"},
@@ -101,6 +105,10 @@ image_template = {
             "well_id": {"type": "long"},
             "wellsample_id": {"type": "long"},
             "name": {
+                "type": "text",
+                "fields": {"keyvalue": {"type": "keyword"}},
+            },  # noqa
+            "description": {
                 "type": "text",
                 "fields": {"keyvalue": {"type": "keyword"}},
             },  # noqa

--- a/omero_search_engine/cache_functions/elasticsearch/sql_to_csv.py
+++ b/omero_search_engine/cache_functions/elasticsearch/sql_to_csv.py
@@ -25,7 +25,7 @@ from string import Template
 
 image_sql = Template(
     """
-select image.id, image.owner_id, image.experiment, image.group_id,
+select image.id, image.description, image.owner_id, image.experiment, image.group_id,
 image.name as name, annotation_mapvalue.name as mapvalue_name,
 annotation_mapvalue.value as mapvalue_value,
 annotation_mapvalue.index as mapvalue_index,
@@ -64,7 +64,7 @@ images_sql_to_csv = (
 
 plate_sql = Template(
     """
-select plate.id, plate.owner_id, plate.group_id,
+select plate.id, plate.owner_id, plate.group_id,plate.description,
 plate.name as name, annotation_mapvalue.name as mapvalue_name,
 annotation_mapvalue.value as mapvalue_value,
 annotation_mapvalue.index as mapvalue_index from plate
@@ -84,7 +84,7 @@ plate_sql_to_csv = (
 
 project_sql = Template(
     """
-select project.id, project.owner_id, project.group_id,
+select project.id, project.owner_id, project.group_id, project.description,
 project.name as name, annotation_mapvalue.name as mapvalue_name,
 annotation_mapvalue.value as mapvalue_value,
 annotation_mapvalue.index as mapvalue_index
@@ -106,7 +106,8 @@ WITH CSV HEADER""".format(
 
 screen_sql = Template(
     """
-select screen.id, screen.owner_id, screen.group_id,  screen.name as name,
+select screen.id, screen.owner_id, screen.group_id,
+screen.name as name,screen.description,
 annotation_mapvalue.name as mapvalue_name,
 annotation_mapvalue.value as mapvalue_value,
 annotation_mapvalue.index as mapvalue_index from screen

--- a/omero_search_engine/cache_functions/elasticsearch/transform_data.py
+++ b/omero_search_engine/cache_functions/elasticsearch/transform_data.py
@@ -177,6 +177,7 @@ def prepare_images_data(data, doc_type):
         "experiment",
         "group_id",
         "name",
+        "description",
         "mapvalue_name",
         "mapvalue_value",
         "project_name",
@@ -233,6 +234,7 @@ def prepare_data(data, doc_type):
         "owner_id",
         "group_id",
         "name",
+        "description",
         "mapvalue_name",
         "mapvalue_value",
     ]
@@ -348,6 +350,7 @@ def insert_resource_data(folder, resource, from_json):
             "experiment",
             "group_id",
             "name",
+            "description",
             "mapvalue_name",
             "mapvalue_value",
             "mapvalue_index",
@@ -379,6 +382,7 @@ def insert_resource_data(folder, resource, from_json):
                 "owner_id",
                 "group_id",
                 "name",
+                "description",
                 "mapvalue_name",
                 "mapvalue_value",
                 "mapvalue_index",
@@ -560,14 +564,30 @@ def insert_resource_data_from_df(df, resource, lock=None):
 def insert_project_data(folder, project_file):
     file_name = folder + "\\" + project_file
     es_index = "project_keyvalue_pair_metadata"
-    cols = ["id", "owner_id", "group_id", "name", "mapvalue_name", "mapvalue_value"]
+    cols = [
+        "id",
+        "owner_id",
+        "group_id",
+        "name",
+        "description",
+        "mapvalue_name",
+        "mapvalue_value",
+    ]
     handle_file(file_name, es_index, cols)
 
 
 def insert_screen_data(folder, screen_file):
     file_name = folder + "\\" + screen_file
     es_index = "screen_keyvalue_pair_metadata"
-    cols = ["id", "owner_id", "group_id", "name", "mapvalue_name", "mapvalue_value"]
+    cols = [
+        "id",
+        "owner_id",
+        "group_id",
+        "name",
+        "description",
+        "mapvalue_name",
+        "mapvalue_value",
+    ]
     handle_file(file_name, es_index, cols)
 
 
@@ -581,7 +601,15 @@ def insert_well_data(folder, well_file):
 def insert_plate_data(folder, plate_file):
     file_name = folder + "\\" + plate_file
     es_index = "plate_keyvalue_pair_metadata"
-    cols = ["id", "owner_id", "group_id", "name", "mapvalue_name", "mapvalue_value"]
+    cols = [
+        "id",
+        "owner_id",
+        "group_id",
+        "name",
+        "description",
+        "mapvalue_name",
+        "mapvalue_value",
+    ]
     handle_file(file_name, es_index, cols)
 
 

--- a/omero_search_engine/validation/psql_templates.py
+++ b/omero_search_engine/validation/psql_templates.py
@@ -49,7 +49,7 @@ inner join imageannotationlink on image.id =imageannotationlink.parent
 inner join annotation_mapvalue on
 annotation_mapvalue.annotation_id=imageannotationlink.child
 where lower(annotation_mapvalue.name)='$name' and
-lower(annotation_mapvalue.value)='$value'"""
+lower(annotation_mapvalue.value)=lower('$value')"""
 )
 
 # Get number of images which satisfy project key-value query
@@ -64,8 +64,8 @@ inner join projectannotationlink
 on project.id =projectannotationlink.parent
 inner join annotation_mapvalue
 on annotation_mapvalue.annotation_id=projectannotationlink.child
-where lower(annotation_mapvalue.name)='$name'
-and lower(annotation_mapvalue.value)='$value'"""
+where lower(annotation_mapvalue.name)=lower('$name')
+and lower(annotation_mapvalue.value)=lower('$value')"""
 )
 
 # Get the  number of images using "in"
@@ -94,7 +94,7 @@ on screen.id =screenannotationlink.parent
 inner join annotation_mapvalue
 on annotation_mapvalue.annotation_id=screenannotationlink.child
 where lower(annotation_mapvalue.name)='$name'
-and lower(annotation_mapvalue.value)='$value'"""
+and lower(annotation_mapvalue.value)=lower('$value')"""
 )
 
 
@@ -117,7 +117,7 @@ inner join datasetimagelink on datasetimagelink.child=image.id
 inner join dataset on datasetimagelink.parent=dataset.id
 inner join projectdatasetlink on dataset.id=projectdatasetlink.child
 inner join project on project.id=projectdatasetlink.parent
-where project.name='$name'"""
+where lower(project.name)=lower('$name')"""
 )
 
 # get images in a screen using id
@@ -141,7 +141,7 @@ inner join well on wellsample.well= well.id
 inner join plate on well.plate=plate.id
 inner join screenplatelink on plate.id=screenplatelink.child
 inner join screen on screen.id=screenplatelink.parent
-where screen.name='$name'"""
+where lower(screen.name)=lower('$name')"""
 )
 
 # get resource id using its name
@@ -159,7 +159,8 @@ inner join datasetimagelink on datasetimagelink.child=image.id
 inner join dataset on datasetimagelink.parent=dataset.id
 inner join projectdatasetlink on dataset.id=projectdatasetlink.child
 inner join project on project.id=projectdatasetlink.parent
-where annotation_mapvalue.name='$key' and  annotation_mapvalue.value ='$value'
+where lower(annotation_mapvalue.name)=lower('$key')
+and lower(annotation_mapvalue.value) =lower('$value')
 """
 )
 
@@ -174,5 +175,6 @@ inner join well on wellsample.well= well.id
 inner join plate on well.plate=plate.id
 inner join screenplatelink on plate.id=screenplatelink.child
 inner join screen on screen.id=screenplatelink.parent
-where annotation_mapvalue.name='$key' and  annotation_mapvalue.value ='$value'"""
+where lower(annotation_mapvalue.name)=lower('$key')
+and  lower(annotation_mapvalue.value) =lower('$value')"""
 )

--- a/omero_search_engine/validation/psql_templates.py
+++ b/omero_search_engine/validation/psql_templates.py
@@ -148,3 +148,31 @@ where screen.name='$name'"""
 res_by_name = Template("""select id from $resource where name $name""")
 
 # idr0015-colin-taraoceans/screenA
+
+projects_count = Template(
+    """
+select DISTINCT project.name from image
+inner join imageannotationlink on image.id=imageannotationlink.parent
+inner join annotation_mapvalue on
+annotation_mapvalue.annotation_id=imageannotationlink.child
+inner join datasetimagelink on datasetimagelink.child=image.id
+inner join dataset on datasetimagelink.parent=dataset.id
+inner join projectdatasetlink on dataset.id=projectdatasetlink.child
+inner join project on project.id=projectdatasetlink.parent
+where annotation_mapvalue.name='$key' and  annotation_mapvalue.value ='$value'
+"""
+)
+
+screens_count = Template(
+    """
+select DISTINCT screen.name from image
+inner join imageannotationlink on image.id = imageannotationlink.parent
+inner join annotation_mapvalue on
+annotation_mapvalue.annotation_id=imageannotationlink.child
+inner join wellsample on wellsample.image=image.id
+inner join well on wellsample.well= well.id
+inner join plate on well.plate=plate.id
+inner join screenplatelink on plate.id=screenplatelink.child
+inner join screen on screen.id=screenplatelink.parent
+where annotation_mapvalue.name='$key' and  annotation_mapvalue.value ='$value'"""
+)

--- a/omero_search_engine/validation/results_validator.py
+++ b/omero_search_engine/validation/results_validator.py
@@ -292,33 +292,33 @@ class Validator(object):
         if search_engine_results["results"].get("results"):
             for item in search_engine_results["results"].get("results"):
                 if item["type"] == "screen":
-                    if item["Name (IDR number)"] in screens_results_idr:
+                    if item["name"] in screens_results_idr:
                         mes = (
                             "Screen %s is found in the PostgreSQL results"
-                            % item["Name (IDR number)"]
+                            % item["name"]
                         )
                         mess.append(mes)
                         search_omero_app.logger.info(mes)
                     else:
                         mes = (
                             "Erro, screen %s is not found in the PostgreSQL results"
-                            % item["Name (IDR number)"]
+                            % item["name"]
                         )
                         mess.append(mes)
                         search_omero_app.logger.info(mes)
 
                 elif item["type"] == "project":
-                    if item["Name (IDR number)"] in projects_results_idr:
+                    if item["name"] in projects_results_idr:
                         mes = (
                             "Project %s is found in the PostgreSQL results"
-                            % item["Name (IDR number)"]
+                            % item["name"]
                         )
                         mess.append(mes)
                         search_omero_app.logger.info(mes)
                     else:
                         mes = (
                             "Error, project %s is not found in the PostgreSQL results"
-                            % item["Name (IDR number)"]
+                            % item["name"]
                         )
                         mess.append(mes)
                         search_omero_app.logger.info(mes)

--- a/omero_search_engine/validation/results_validator.py
+++ b/omero_search_engine/validation/results_validator.py
@@ -22,6 +22,7 @@ from datetime import datetime
 from omero_search_engine.api.v1.resources.query_handler import (
     determine_search_results_,
     query_validator,
+    simple_search,
 )
 from omero_search_engine.validation.psql_templates import (
     query_images_key_value,
@@ -30,6 +31,8 @@ from omero_search_engine.validation.psql_templates import (
     query_images_in_project_name,
     query_images_screen_name,
     query_image_or,
+    screens_count,
+    projects_count,
 )
 import os
 
@@ -40,6 +43,8 @@ query_methods = {
     "project_name": query_images_in_project_name,
     "screen_name": query_images_screen_name,
     "query_image_or": query_image_or,
+    "screens_count": screens_count,
+    "projects_count": projects_count,
 }
 
 
@@ -252,6 +257,96 @@ class Validator(object):
         else:
             search_omero_app.logger.info("The query is not valid")
 
+    def get_containers_test_cases(self):
+        """
+        Compare the results containers from postgres and the searchengine
+        """
+        mess = []
+        mes = "Checking the results containers for name '%s' and value '%s'" % (
+            self.name,
+            self.value,
+        )
+        mess.append(mes)
+        search_omero_app.logger.info(mes)
+        screens_count_sql = query_methods["screens_count"].substitute(
+            key=self.name, value=self.value
+        )
+        projects_count_sql = query_methods["projects_count"].substitute(
+            key=self.name, value=self.value
+        )
+        conn = search_omero_app.config["database_connector"]
+        screens_results = conn.execute_query(screens_count_sql)
+        projects_results = conn.execute_query(projects_count_sql)
+        screens_results_idr = [item["name"] for item in screens_results]
+        projects_results_idr = [item["name"] for item in projects_results]
+        search_engine_results = simple_search(
+            self.name,
+            self.value,
+            "equals",
+            False,
+            None,
+            self.resource,
+            None,
+            return_containers=True,
+        )
+        if search_engine_results["results"].get("results"):
+            for item in search_engine_results["results"].get("results"):
+                if item["type"] == "screen":
+                    if item["Name (IDR number)"] in screens_results_idr:
+                        mes = (
+                            "Screen %s is found in the PostgreSQL results"
+                            % item["Name (IDR number)"]
+                        )
+                        mess.append(mes)
+                        search_omero_app.logger.info(mes)
+                    else:
+                        mes = (
+                            "Erro, screen %s is not found in the PostgreSQL results"
+                            % item["Name (IDR number)"]
+                        )
+                        mess.append(mes)
+                        search_omero_app.logger.info(mes)
+
+                elif item["type"] == "project":
+                    if item["Name (IDR number)"] in projects_results_idr:
+                        mes = (
+                            "Project %s is found in the PostgreSQL results"
+                            % item["Name (IDR number)"]
+                        )
+                        mess.append(mes)
+                        search_omero_app.logger.info(mes)
+                    else:
+                        mes = (
+                            "Error, project %s is not found in the PostgreSQL results"
+                            % item["Name (IDR number)"]
+                        )
+                        mess.append(mes)
+                        search_omero_app.logger.info(mes)
+            no_results_searchengine = len(
+                search_engine_results["results"].get("results")
+            )
+            no_results_postgresql = len(screens_results_idr) + len(projects_results_idr)
+            if no_results_postgresql == no_results_searchengine:
+                mes = (
+                    "The number of the results from PostgreSQL "
+                    "and the Searchengine (%s) are equal" % no_results_postgresql
+                )
+                mess.append(mes)
+                search_omero_app.logger.info(mes)
+            else:
+                mes = (
+                    "Error, the number of the results from PostgreSQL %s "
+                    "and the Searchengine %s are not equal"
+                    % (no_results_postgresql, no_results_searchengine)
+                )
+                mess.append(mes)
+                search_omero_app.logger.info(mes)
+        else:
+            mes = "No results found in the Searchengine"
+            mess.append(mes)
+            search_omero_app.logger.info(mes)
+        return mess
+
     def compare_results(self):
         """
         call the results
@@ -286,8 +381,8 @@ class Validator(object):
                     "No of the retuned results are similar ..."
                 )
                 return (
-                    "equal (%s images), \n database server query time= %s,\
-                     searchengine query time= %s"
+                    "equal (%s images), \n database server query time= %s,"
+                    "searchengine query time= %s"
                     % (len(self.postgres_results), sql_time, searchengine_time)
                 )
         if self.searchengine_results:
@@ -330,11 +425,15 @@ def validate_queries(json_file, deep_check):
             )
             validator = Validator(deep_check)
             validator.set_simple_query(resource, name, value)
+            if resource == "image":
+                mess = validator.get_containers_test_cases()
+                messages = messages + mess
+
             res = validator.compare_results()
             elabsed_time = str(datetime.now() - start_time)
             messages.append(
-                "Results form  PostgreSQL and search engine\
-                 for name: %s , value: %s are: %s"
+                "Results from PostgreSQL and search engine for "
+                "name '%s', value '%s', are: %s"
                 % (validator.name, validator.value, res)
             )
             search_omero_app.logger.info("Total time=%s" % elabsed_time)
@@ -346,8 +445,8 @@ def validate_queries(json_file, deep_check):
             validator_c.set_complex_query(name, cases)
             res = validator_c.compare_results()
             messages.append(
-                "Results form  PostgreSQL and search engine\
-                for %s name: %s and value: %s are %s"
+                "Results from PostgreSQL and search engine for %s name"
+                "'%s' and value '%s' are %s"
                 % (name, validator_c.name, validator_c.value, res)
             )
             search_omero_app.logger.info(


### PR DESCRIPTION
This PR addresses issue #34 and issue #35. 

The `/submitquery_returnstudies/` endpoint will return all the containers, each will  have an IDR name, the image count, a title and the recourse type (project, screen). It should be something like this:

```
 {
        "Name (IDR number)": "idr0041-cai-mitoticatlas/experimentA",
        "image count": 60480,
        "title": "Experimental and computational framework for a dynamic protein atlas of human cell division",
        "type": "project"
}
```
It has been deployed on the idr-testing.

@will-moore Could you please check this and let me know what you think?
