### PR TITLE
bookmark example shows returned page

### DIFF
--- a/examples/search_with_bookmark_paging_using_submitquery.py
+++ b/examples/search_with_bookmark_paging_using_submitquery.py
@@ -64,8 +64,9 @@ def call_omero_searchengine_return_results(url, data=None, method="post"):
             if res["id"] in ids:
                 raise Exception(" Id dublicated error  %s" % res["id"])
             ids.append(res["id"])
-        global total_pages
+        global total_pages, page
         total_pages = returned_results["results"]["total_pages"]
+        page = returned_results["results"]["page"]
         return bookmark, total_results
 
     except Exception as ex:
@@ -118,7 +119,6 @@ bookmark, total_results = call_omero_searchengine_return_results(
 
 while len(received_results) < total_results:
 
-    page += 1
     query_data_ = {"query_details": {"and_filters": and_filters}, "bookmark": bookmark}
     query_data_json_ = json.dumps(query_data_)
 


### PR DESCRIPTION
See https://github.com/ome/omero_search_engine/issues/47

This illustrates an issue with the returned `page` value when using bookmarks.
With the change here, the output of running this script shows that the page is always `2`:

```
$ python examples/search_with_bookmark_paging_using_submitquery.py 
INFO:root:bookmark: [3561267], page: 2, / 213 received results: 2000 / 212431
INFO:root:bookmark: [3586902], page: 2, / 213 received results: 3000 / 212431
INFO:root:bookmark: [3613328], page: 2, / 213 received results: 4000 / 212431
INFO:root:bookmark: [3639321], page: 2, / 213 received results: 5000 / 212431
INFO:root:bookmark: [3664557], page: 2, / 213 received results: 6000 / 212431
INFO:root:bookmark: [3689708], page: 2, / 213 received results: 7000 / 212431
INFO:root:bookmark: [3716314], page: 2, / 213 received results: 8000 / 212431
...
```