### PR TITLE
Return the exact match first

### DIFF
--- a/omero_search_engine/api/v1/resources/resource_analyser.py
+++ b/omero_search_engine/api/v1/resources/resource_analyser.py
@@ -135,6 +135,7 @@ def search_index_for_values_get_all_buckets(e_index, query):
                 "order": "asc",
             }
         },
+        {"items_in_the_bucket": "desc"},
         {"id": "asc"},
     ]
     co = 0
@@ -156,7 +157,8 @@ def search_index_for_values_get_all_buckets(e_index, query):
             return returened_results
         bookmark = [
             int(res["hits"]["hits"][-1]["sort"][0]),
-            res["hits"]["hits"][-1]["sort"][1],
+            int(res["hits"]["hits"][-1]["sort"][1]),
+            res["hits"]["hits"][-1]["sort"][2],
         ]
     return returened_results
 
@@ -337,11 +339,12 @@ def prepare_search_results(results, size=0):
 
     if size > 0:
         results_dict["total_number_of_all_buckets "] = size
-        if total_number < size:
+        if number_of_buckets < size:
             # this should be later to get the next page
             results_dict["bookmark"] = [
                 int(results["hits"]["hits"][-1]["sort"][0]),
-                results["hits"]["hits"][-1]["sort"][1],
+                int(results["hits"]["hits"][-1]["sort"][1]),
+                results["hits"]["hits"][-1]["sort"][2],
             ]
     return results_dict
 
@@ -587,7 +590,7 @@ resource_key_values_buckets_template = Template(
         "script": "doc['Value.keyvaluenormalize'].value.length()",
         "type": "number",
         "order": "asc"
-    }},{"id": "asc"}]}"""
+    }},{"items_in_the_bucket": "desc"}, {"id": "asc"}]}"""
 )
 
 key_values_buckets_template_2 = Template(

--- a/omero_search_engine/api/v1/resources/resource_analyser.py
+++ b/omero_search_engine/api/v1/resources/resource_analyser.py
@@ -394,7 +394,7 @@ def get_key_values_return_contents(name, resource, csv):
     return jsonify(resource_keys)
 
 
-def adjuest_value(value):
+def adjust_value(value):
     """
     Adjust the value to search terms which includes * or ?
     and support search special characters
@@ -418,7 +418,7 @@ def query_cashed_bucket_part_value_keys(
     """
     if name:
         name = name.strip()
-    value = adjuest_value(value)
+    value = adjust_value(value)
     if resource != "all":
         query = key_part_values_buckets_template.substitute(
             name=name, value=value, resource=resource
@@ -468,7 +468,7 @@ def search_value_for_resource(table_, value, es_index="key_value_buckets_informa
     send the request to elasticsearch and format the results
     It support wildcard operations only
     """
-    value = adjuest_value(value)
+    value = adjust_value(value)
 
     if table_ != "all":
         query = resource_key_values_buckets_template.substitute(

--- a/omero_search_engine/api/v1/resources/resource_analyser.py
+++ b/omero_search_engine/api/v1/resources/resource_analyser.py
@@ -28,9 +28,6 @@ from omero_search_engine.api.v1.resources.utils import (
 )
 import math
 
-
-not_allowed_chars = ['"', "\\"]
-
 key_number_search_template = Template(
     """
 {"size":0,"aggs":{"value_search":{"nested":{"path":"key_values"},
@@ -397,6 +394,18 @@ def get_key_values_return_contents(name, resource, csv):
     return jsonify(resource_keys)
 
 
+def adjuest_value(value):
+    """
+    Adjust the value to search terms which includes * or ?
+    and support search special characters
+    """
+    if value:
+        value = value.strip().strip().lower()
+        value = value.translate({ord(c): "\\\\%s" % c for c in "*?&"})
+        value = value.translate({ord(c): "\\%s" % c for c in '"'})
+    return value
+
+
 def query_cashed_bucket_part_value_keys(
     name, value, resource, es_index="key_value_buckets_information"
 ):
@@ -409,10 +418,7 @@ def query_cashed_bucket_part_value_keys(
     """
     if name:
         name = name.strip()
-    if value:
-        value = value.strip()
-        if "*" not in value and "?" not in value:
-            value = "*%s*" % value
+    value = adjuest_value(value)
     if resource != "all":
         query = key_part_values_buckets_template.substitute(
             name=name, value=value, resource=resource
@@ -462,22 +468,9 @@ def search_value_for_resource(table_, value, es_index="key_value_buckets_informa
     send the request to elasticsearch and format the results
     It support wildcard operations only
     """
-    if value:
-        value = value.strip().lower()
+    value = adjuest_value(value)
 
-    # query=value_all_buckets_template.substitute(value=value)
-    # check the the value, if contains ", it will remove it
-
-    # check thevalue if contains \ it wil replaced it with \\
-
-    # the if the value does not contain *, it will make it
-    # generic wildcard by adding * at the start and at the end
     if table_ != "all":
-        if '"' in value:
-            value = value.replace('"', "")
-        elif "\\" in value:
-            value = value.replace("\\", "\\\\")
-        value = "*{value}*".format(value=value)
         query = resource_key_values_buckets_template.substitute(
             value=value, resource=table_
         )
@@ -485,16 +478,9 @@ def search_value_for_resource(table_, value, es_index="key_value_buckets_informa
 
         return prepare_search_results(res)
     else:
-        for crh in not_allowed_chars:
-            if crh in value:
-                return build_error_message(
-                    " , ".join(not_allowed_chars) + " are not allowed in the query term"
-                )
         # If the user does not specify anything,
         # it will add * at the start and at the end to
         # return all the values which contain the search term
-        if "*" not in value and "?" not in value:
-            value = "*{value}*".format(value=value)
         returned_results = {}
         for table in resource_elasticsearchindex:
             # ignore image1 as it is used for testing
@@ -528,7 +514,7 @@ key_part_values_buckets_template = Template(
     """
 {"query":{"bool":{"must":[{"bool":{
 "must":[{"match":{"Attribute.keyrnamenormalize":"$name"}},
-{"wildcard":{"Value.keyvaluenormalize":"$value"}}
+{"wildcard":{"Value.keyvaluenormalize":"*$value*"}}
 ]
 }},{
 "bool": {"must": [
@@ -573,7 +559,7 @@ value_all_buckets_template = Template(
 resource_key_values_buckets_template = Template(
     """
 {"query":{"bool":{"must":[{"bool":{
-"must":{"wildcard":{"Value.keyvaluenormalize":"$value"}}}},{
+"must":{"wildcard":{"Value.keyvaluenormalize":"*$value*"}}}},{
 "bool": {"must": {"match":
 {"resource.keyresource": "$resource"}}}}]}},
 "size": 9999, "sort": [{"items_in_the_bucket": "desc"}]}"""

--- a/omero_search_engine/api/v1/resources/resource_analyser.py
+++ b/omero_search_engine/api/v1/resources/resource_analyser.py
@@ -25,6 +25,7 @@ import os
 from omero_search_engine.api.v1.resources.utils import (
     resource_elasticsearchindex,
     build_error_message,
+    adjust_value,
 )
 import math
 
@@ -392,18 +393,6 @@ def get_key_values_return_contents(name, resource, csv):
             )
 
     return jsonify(resource_keys)
-
-
-def adjust_value(value):
-    """
-    Adjust the value to search terms which includes * or ?
-    and support search special characters
-    """
-    if value:
-        value = value.strip().strip().lower()
-        value = value.translate({ord(c): "\\\\%s" % c for c in "*?&"})
-        value = value.translate({ord(c): "\\%s" % c for c in '"'})
-    return value
 
 
 def query_cashed_bucket_part_value_keys(

--- a/omero_search_engine/api/v1/resources/utils.py
+++ b/omero_search_engine/api/v1/resources/utils.py
@@ -32,6 +32,18 @@ mm = main_dir.replace("omero_search_engine/api/v2/resources", "")
 sys.path.append(mm)
 
 
+def adjust_value(value):
+    """
+    Adjust the value to search terms which includes * or ?
+    and support search special characters
+    """
+    if value:
+        value = value.strip().strip().lower()
+        value = value.translate({ord(c): "\\\\%s" % c for c in "*?&"})
+        value = value.translate({ord(c): "\\%s" % c for c in '"'})
+    return value
+
+
 def get_resource_annotation_table(resource_table):
     """
     return the related annotation for the resources table
@@ -314,7 +326,7 @@ def elasticsearch_query_builder(
                     )
                 )
             if operator == "contains":
-                value = "*{value}*".format(value=value)
+                value = "*{value}*".format(value=adjust_value(value))
                 # _nested_must_part.append(must_name_condition_template.substitute(name=key)) # noqa
                 if case_sensitive:
                     _nested_must_part.append(
@@ -348,7 +360,7 @@ def elasticsearch_query_builder(
             elif operator in ["not_equals", "not_contains"]:
                 # nested_must_part.append(nested_keyvalue_pair_query_template.substitute(nested=must_name_condition_template.substitute(name=key)))
                 if operator == "not_contains":
-                    value = "*{value}*".format(value=value)
+                    value = "*{value}*".format(value=adjust_value(value))
                     if case_sensitive:
                         nested_must_part.append(
                             nested_keyvalue_pair_query_template.substitute(


### PR DESCRIPTION
In this PR,  the searchengine will try to find the exact match for the query using `/searchvalues/` endpoint and will subsequently include possible matches.
It is related to the bug on line 20 in the phase 1 test sheet (https://docs.google.com/spreadsheets/d/1yO26q5hAi-Df0s54ZLEiXcc_LO5SOPD8XnDayQx6wjw/edit#gid=1049754075)
It has been deployed on the idr-testing.
This PR is based on PR #51 
@will-moore @pwalczysko Please check it and let me know what you think.