### PR TITLE
Pagination

### DIFF
--- a/examples/pagination_searchannotation.py
+++ b/examples/pagination_searchannotation.py
@@ -31,11 +31,13 @@ base_url = "http://127.0.0.1:5577/api/v1/"
 
 logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 
+
 def get_bookmark(pagination_dict):
-    next_page=pagination_dict["next_page"]
+    next_page = pagination_dict["next_page"]
     for page_rcd in pagination_dict["page_records"]:
-        if page_rcd["page"]==next_page:
+        if page_rcd["page"] == next_page:
             return page_rcd["bookmark"]
+
 
 def find_all_the_results(query, main_attributes):
     received_results_data = []
@@ -81,19 +83,19 @@ def find_all_the_results(query, main_attributes):
     logging.info(
         "page: %s, received results: %s"
         % (
-             (str(page) + "/" + str(total_pages)),
+            (str(page) + "/" + str(total_pages)),
             (str(received_results) + "/" + str(total_results)),
         )
     )
-    #it is not used in the request, it is used to comapre requests using
-    #pagination and bookmark
+    # it is not used in the request, it is used to comapre requests using
+    # pagination and bookmark
     bookmark = get_bookmark(pagination_dict)
-    page=pagination_dict["next_page"]
-    ids=[]
+    page = pagination_dict["next_page"]
+    ids = []
     while page:
         query_data = {
             "query": {"query_details": returned_results["query_details"]},
-            "pagination": pagination_dict
+            "pagination": pagination_dict,
         }
         query_data_json = json.dumps(query_data)
         resp = requests.post(
@@ -106,15 +108,15 @@ def find_all_the_results(query, main_attributes):
             logging.info("%s, Error: %s" % (resp.text, e))
             return
 
-        #bookmark = returned_results["results"].get("bookmark")
+        # bookmark = returned_results["results"].get("bookmark")
         pagination_dict = returned_results["results"].get("pagination")
 
         received_results = received_results + len(
             returned_results["results"]["results"]
         )
         for res in returned_results["results"]["results"]:
-            if res['id'] in ids:
-                raise Exception ("Image id %s is added before."%res["id"])
+            if res["id"] in ids:
+                raise Exception("Image id %s is added before." % res["id"])
             ids.append(res["id"])
             received_results_data.append(res)
 
@@ -127,11 +129,10 @@ def find_all_the_results(query, main_attributes):
             )
         )
         page = pagination_dict.get("next_page")
-        bookmark=get_bookmark(pagination_dict)
+        bookmark = get_bookmark(pagination_dict)
 
     logging.info("Total received results: %s" % len(received_results_data))
     return received_results_data
-
 
 
 # Find images of cells where a specific gene was targeted

--- a/examples/pagination_searchannotation.py
+++ b/examples/pagination_searchannotation.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2022 University of Dundee & Open Microscopy Environment.
+# All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import json
+import logging
+import requests
+import sys
+
+# url to send the query
+image_ext = "/resources/image/searchannotation/"
+# url to get the next page for a query, bookmark is needed
+image_page_ext = "/resources/image/searchannotation_page/"
+# search engine url
+base_url = "http://127.0.0.1:5577/api/v1/"
+
+logging.basicConfig(stream=sys.stdout, level=logging.INFO)
+
+def get_bookmark(pagination_dict):
+    next_page=pagination_dict["next_page"]
+    for page_rcd in pagination_dict["page_records"]:
+        if page_rcd["page"]==next_page:
+            return page_rcd["bookmark"]
+
+def find_all_the_results(query, main_attributes):
+    received_results_data = []
+    query_data = {"query": {"query_details": query, "main_attributes": main_attributes}}
+    resp = requests.post(
+        url="%s%s" % (base_url, image_ext), data=json.dumps(query_data)
+    )
+
+    res = resp.text
+    try:
+        returned_results = json.loads(res)
+    except Exception:
+        logging.info(res)
+        return []
+
+    if not returned_results.get("results") or len(returned_results["results"]) == 0:
+        logging.info("Your query returns no results")
+        return []
+
+    logging.info("Query results:")
+    total_results = returned_results["results"]["size"]
+    logging.info("Total no of result records %s" % total_results)
+    logging.info(
+        "Server query time: %s seconds" % returned_results["server_query_time"]
+    )
+    logging.info(
+        "Included results in the current page %s"
+        % len(returned_results["results"]["results"])
+    )
+
+    for res in returned_results["results"]["results"]:
+        received_results_data.append(res)
+
+    received_results = len(returned_results["results"]["results"])
+    # set the bookmark to used in the next the page,
+    # if the number of pages is greater than 1
+    # get the total number of pages
+    total_pages = returned_results["results"]["total_pages"]
+    pagination_dict = returned_results["results"].get("pagination")
+
+    page = pagination_dict["current_page"]
+
+    logging.info(
+        "page: %s, received results: %s"
+        % (
+             (str(page) + "/" + str(total_pages)),
+            (str(received_results) + "/" + str(total_results)),
+        )
+    )
+    #it is not used in the request, it is used to comapre requests using
+    #pagination and bookmark
+    bookmark = get_bookmark(pagination_dict)
+    page=pagination_dict["next_page"]
+    ids=[]
+    while page:
+        query_data = {
+            "query": {"query_details": returned_results["query_details"]},
+            "pagination": pagination_dict
+        }
+        query_data_json = json.dumps(query_data)
+        resp = requests.post(
+            url="%s%s" % (base_url, image_page_ext), data=query_data_json
+        )
+        res = resp.text
+        try:
+            returned_results = json.loads(res)
+        except Exception as e:
+            logging.info("%s, Error: %s" % (resp.text, e))
+            return
+
+        #bookmark = returned_results["results"].get("bookmark")
+        pagination_dict = returned_results["results"].get("pagination")
+
+        received_results = received_results + len(
+            returned_results["results"]["results"]
+        )
+        for res in returned_results["results"]["results"]:
+            if res['id'] in ids:
+                raise Exception ("Image id %s is added before."%res["id"])
+            ids.append(res["id"])
+            received_results_data.append(res)
+
+        logging.info(
+            "bookmark: %s, page: %s, received results: %s"
+            % (
+                bookmark,
+                (str(page) + "/" + str(total_pages)),
+                (str(received_results) + "/" + str(total_results)),
+            )
+        )
+        page = pagination_dict.get("next_page")
+        bookmark=get_bookmark(pagination_dict)
+
+    logging.info("Total received results: %s" % len(received_results_data))
+    return received_results_data
+
+
+
+# Find images of cells where a specific gene was targeted
+# Cell line = "HeLa" and Gene Symbol = "KIF11"
+
+# and filters
+and_filters = [
+    {"name": "Cell Line", "value": "HeLa", "operator": "equals"},
+    {"name": "Gene Symbol", "value": "KIF11", "operator": "equals"},
+]
+main_attributes = []
+query = {"and_filters": and_filters}
+
+received_results_data = find_all_the_results(query, main_attributes)
+
+# Another example: Cell line = "U2OS" and Gene Symbol = "RHEB"
+
+and_filters_2 = [
+    {"name": "Cell Line", "value": "U2OS", "operator": "not_equals"},
+    {"name": "Gene Symbol", "value": "RHEB", "operator": "equals"},
+]
+query_2 = {"and_filters": and_filters_2, "case_sensitive": True}
+received_results_data_2 = find_all_the_results(query_2, main_attributes)

--- a/examples/pagination_searchannotation.py
+++ b/examples/pagination_searchannotation.py
@@ -21,13 +21,14 @@ import json
 import logging
 import requests
 import sys
+from utils import base_url
 
 # url to send the query
 image_ext = "/resources/image/searchannotation/"
 # url to get the next page for a query, bookmark is needed
 image_page_ext = "/resources/image/searchannotation_page/"
 # search engine url
-base_url = "http://127.0.0.1:5577/api/v1/"
+
 
 logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 

--- a/examples/pagination_submitquery.py
+++ b/examples/pagination_submitquery.py
@@ -33,20 +33,21 @@ received_results = []
 page = 1
 ids = []
 total_pages = 0
-pagination_dict=None
-next_page=None
+pagination_dict = None
+next_page = None
+
 
 def get_current_page_bookmark(pagination_dict):
-    current_page=pagination_dict["current_page"]
-    bookmark=None
+    current_page = pagination_dict["current_page"]
+    bookmark = None
     for page_rcd in pagination_dict["page_records"]:
-        if page_rcd["page"]==current_page:
-            bookmark= page_rcd["bookmark"]
+        if page_rcd["page"] == current_page:
+            bookmark = page_rcd["bookmark"]
     return current_page, bookmark
 
 
 def call_omero_searchengine_return_results(url, data=None, method="post"):
-    global page, total_pages,pagination_dict, next_page
+    global page, total_pages, pagination_dict, next_page
     if method == "post":
         resp = requests.post(url, data=data)
     else:
@@ -63,11 +64,11 @@ def call_omero_searchengine_return_results(url, data=None, method="post"):
         # get the bookmark which will be used to call
         # the next page of the results
         pagination_dict = returned_results["results"].get("pagination")
-        page, bookmark=get_current_page_bookmark(pagination_dict)
-        page=pagination_dict.get("current_page")
+        page, bookmark = get_current_page_bookmark(pagination_dict)
+        page = pagination_dict.get("current_page")
         # get the size of the total results
         total_pages = pagination_dict.get("total_pages")
-        next_page= pagination_dict.get("next_page")
+        next_page = pagination_dict.get("next_page")
 
         total_results = returned_results["results"]["size"]
 
@@ -129,8 +130,11 @@ logging.info(
     % (page, total_pages, len(received_results), total_results)
 )
 
-while next_page:#len(received_results) < total_results:
-    query_data_ = {"query_details": {"and_filters": and_filters}, "pagination": pagination_dict}
+while next_page:  # len(received_results) < total_results:
+    query_data_ = {
+        "query_details": {"and_filters": and_filters},
+        "pagination": pagination_dict,
+    }
     query_data_json_ = json.dumps(query_data_)
 
     bookmark, total_results = call_omero_searchengine_return_results(

--- a/examples/pagination_submitquery.py
+++ b/examples/pagination_submitquery.py
@@ -22,9 +22,8 @@ import logging
 import json
 import requests
 import sys
+from utils import base_url
 
-# search engine url
-base_url = "http://127.0.0.1:5577/api/v1/"
 submit_query_url = f"{base_url}resources/submitquery/"  # noqa
 
 logging.basicConfig(stream=sys.stdout, level=logging.INFO)

--- a/examples/pagination_submitquery.py
+++ b/examples/pagination_submitquery.py
@@ -25,7 +25,7 @@ import sys
 
 # search engine url
 base_url = "http://127.0.0.1:5577/api/v1/"
-submit_query_url = "http://127.0.0.1:5577/api/v1/resources/submitquery"  # noqa
+submit_query_url = f"{base_url}resources/submitquery/"  # noqa
 
 logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 

--- a/examples/pagination_submitquery.py
+++ b/examples/pagination_submitquery.py
@@ -113,7 +113,7 @@ and_filters = [
     {
         "name": "Pathology",
         "value": "Normal tissue, NOS",
-        "operator": "not_equals",
+        "operator": "equals",
         "resource": "image",
     },
 ]

--- a/examples/pagination_submitquery.py
+++ b/examples/pagination_submitquery.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2022 University of Dundee & Open Microscopy Environment.
+# All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import datetime
+import logging
+import json
+import requests
+import sys
+
+# search engine url
+base_url = "http://127.0.0.1:5577/api/v1/"
+submit_query_url = "http://127.0.0.1:5577/api/v1/resources/submitquery"  # noqa
+
+logging.basicConfig(stream=sys.stdout, level=logging.INFO)
+
+received_results = []
+page = 1
+ids = []
+total_pages = 0
+pagination_dict=None
+next_page=None
+
+def get_current_page_bookmark(pagination_dict):
+    current_page=pagination_dict["current_page"]
+    bookmark=None
+    for page_rcd in pagination_dict["page_records"]:
+        if page_rcd["page"]==current_page:
+            bookmark= page_rcd["bookmark"]
+    return current_page, bookmark
+
+
+def call_omero_searchengine_return_results(url, data=None, method="post"):
+    global page, total_pages,pagination_dict, next_page
+    if method == "post":
+        resp = requests.post(url, data=data)
+    else:
+        resp = requests.get(url)
+    try:
+        returned_results = json.loads(resp.text)
+        if not returned_results.get("results"):
+            logging.info(returned_results)
+            sys.exit()
+
+        elif len(returned_results["results"]) == 0:
+            logging.info("Your query returns no results")
+            sys.exit()
+        # get the bookmark which will be used to call
+        # the next page of the results
+        pagination_dict = returned_results["results"].get("pagination")
+        page, bookmark=get_current_page_bookmark(pagination_dict)
+        page=pagination_dict.get("current_page")
+        # get the size of the total results
+        total_pages = pagination_dict.get("total_pages")
+        next_page= pagination_dict.get("next_page")
+
+        total_results = returned_results["results"]["size"]
+
+        for res in returned_results["results"]["results"]:
+            received_results.append(res)
+            if res["id"] in ids:
+                raise Exception(" Id dublicated error  %s" % res["id"])
+            ids.append(res["id"])
+        return bookmark, total_results
+
+    except Exception as ex:
+        logging.info("Error: %s" % ex)
+
+
+"""
+If the user needs to search for unhealthy human female breast images
+
+Clause for Human:  
+Organism='Homo sapiens' ==> {"name": "Organism", "value": "Homo sapiens", "operator": "equals","resource": "image"}  # noqa
+Restrict the search to "female":
+Sex='Female' ==> {"name": "Sex", "value": "Female", "operator": "equals","resource": "image"}  # noqa
+Restrict the search to "breast":
+Organism Part='Breast' ==>{"name": "Organism Part", "value": "Breast", "operator": "equals","resource": "image"}  # noqa
+Return only the images of "abnormal" tissues: 
+Pathology != 'Normal tissue, NOS' ==> {"name": "Pathology", "value": "Normal tissue, NOS", "operator": "not_equals","resource": "image"}  # noqa
+In terms of clauses we only have and_filters which contains 4 clauses
+"""
+start = datetime.datetime.now()
+and_filters = [
+    {
+        "name": "Organism",
+        "value": "Homo sapiens",
+        "operator": "equals",
+        "resource": "image",
+    },
+    {
+        "name": "Organism Part",
+        "value": "Breast",
+        "operator": "equals",
+        "resource": "image",
+    },
+    {"name": "Sex", "value": "Female", "operator": "equals", "resource": "image"},
+    {
+        "name": "Pathology",
+        "value": "Normal tissue, NOS",
+        "operator": "not_equals",
+        "resource": "image",
+    },
+]
+
+query_data = {"query_details": {"and_filters": and_filters}}
+
+query_data_json = json.dumps(query_data)
+bookmark, total_results = call_omero_searchengine_return_results(
+    submit_query_url, data=query_data_json
+)
+logging.info(
+    "page: %s, / %s received results: %s / %s"
+    % (page, total_pages, len(received_results), total_results)
+)
+
+while next_page:#len(received_results) < total_results:
+    query_data_ = {"query_details": {"and_filters": and_filters}, "pagination": pagination_dict}
+    query_data_json_ = json.dumps(query_data_)
+
+    bookmark, total_results = call_omero_searchengine_return_results(
+        submit_query_url, data=query_data_json_
+    )
+
+    logging.info(
+        "bookmark: %s, page: %s, / %s received results: %s / %s"
+        % (bookmark, page, total_pages, len(received_results), total_results)
+    )

--- a/examples/return_containers_only.py
+++ b/examples/return_containers_only.py
@@ -21,14 +21,10 @@ import logging
 import json
 import requests
 import sys
-
+from utils import base_url
 
 # url to send the query
 image_search = "/resources/image/search/"
-# search engine url
-base_url = "http://127.0.0.1:5577/api/v1/"
-# base_url ="https://idr-testing.openmicroscopy.org/searchengineapi/api/v1/"  # noqa
-
 
 logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 """

--- a/examples/return_studies.py
+++ b/examples/return_studies.py
@@ -21,15 +21,10 @@ import logging
 import json
 import requests
 import sys
+from utils import base_url
 
 # url to send the query
-# search engine url
-submit_query_url = (
-    "http://127.0.0.1:5577/api/v1/resources/submitquery/containers/"  # noqa
-)
-
-# base_url ="https://idr-testing.openmicroscopy.org/searchengineapi/api/v1/"
-
+submit_query_url = f"{base_url}resources/submitquery/containers/"
 
 logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 """

--- a/examples/return_studies.py
+++ b/examples/return_studies.py
@@ -79,9 +79,7 @@ data = {
 }
 
 resp = requests.post(submit_query_url, data=json.dumps(data))
-ss=resp.text
 returned_results = json.loads(resp.text)
-print (returned_results)
 if returned_results.get("results"):
     if len(returned_results.get("results").get("results")) == 0:
         logging.info("No results is found")

--- a/examples/return_studies.py
+++ b/examples/return_studies.py
@@ -25,7 +25,7 @@ import sys
 # url to send the query
 # search engine url
 submit_query_url = (
-    "http://127.0.0.1:5577/api/v1/resources/submitquery_returnstudies/"  # noqa
+    "http://127.0.0.1:5577/api/v1/resources/submitquery/containers/"  # noqa
 )
 
 # base_url ="https://idr-testing.openmicroscopy.org/searchengineapi/api/v1/"
@@ -79,9 +79,11 @@ data = {
 }
 
 resp = requests.post(submit_query_url, data=json.dumps(data))
+ss=resp.text
 returned_results = json.loads(resp.text)
+print (returned_results)
 if returned_results.get("results"):
     if len(returned_results.get("results").get("results")) == 0:
         logging.info("No results is found")
     for item in returned_results.get("results").get("results"):
-        logging.info("Study: %s" % item.get("Name (IDR number)"))
+        logging.info("Study: %s" % item.get("name"))

--- a/examples/search-using_and_or_clauses.py
+++ b/examples/search-using_and_or_clauses.py
@@ -21,14 +21,13 @@ import logging
 import json
 import requests
 import sys
+from utils import base_url
 
 
 # url to send the query
 image_ext = "/resources/image/searchannotation/"
 # url to get the next page for a query, bookmark is needed
 image_page_ext = "/resources/image/searchannotation_page/"
-# search engine url
-base_url = "http://127.0.0.1:5577/api/v1/"
 
 
 logging.basicConfig(stream=sys.stdout, level=logging.INFO)

--- a/examples/search.py
+++ b/examples/search.py
@@ -22,12 +22,10 @@ import json
 import requests
 import sys
 
+from utils import base_url
 
 # url to send the query
 image_search = "/resources/image/search/"
-# search engine url
-base_url = "http://127.0.0.1:5577/api/v1/"
-# base_url = "https://idr-testing.openmicroscopy.org/searchengine/api/v1/"  # noqa
 
 
 logging.basicConfig(stream=sys.stdout, level=logging.INFO)

--- a/examples/search.py
+++ b/examples/search.py
@@ -26,8 +26,8 @@ import sys
 # url to send the query
 image_search = "/resources/image/search/"
 # search engine url
-# base_url = "http://127.0.0.1:5577/api/v1/"
-base_url = "https://idr-testing.openmicroscopy.org/searchengineapi/api/v1/"  # noqa
+base_url = "http://127.0.0.1:5577/api/v1/"
+#base_url = "https://idr-testing.openmicroscopy.org/searchengine/api/v1/"  # noqa
 
 
 logging.basicConfig(stream=sys.stdout, level=logging.INFO)

--- a/examples/search.py
+++ b/examples/search.py
@@ -27,7 +27,7 @@ import sys
 image_search = "/resources/image/search/"
 # search engine url
 base_url = "http://127.0.0.1:5577/api/v1/"
-#base_url = "https://idr-testing.openmicroscopy.org/searchengine/api/v1/"  # noqa
+# base_url = "https://idr-testing.openmicroscopy.org/searchengine/api/v1/"  # noqa
 
 
 logging.basicConfig(stream=sys.stdout, level=logging.INFO)

--- a/examples/search_for_values.py
+++ b/examples/search_for_values.py
@@ -21,11 +21,10 @@ import logging
 import json
 import requests
 import sys
+from utils import base_url
 
 # url to send the query
 image_value_search = "/resources/image/searchvalues/"
-# searchengine url
-base_url = "http://127.0.0.1:5577/api/v1/"
 logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 
 """

--- a/examples/search_for_values.py
+++ b/examples/search_for_values.py
@@ -32,17 +32,16 @@ logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 If the user needs to search for a value whose attribute is not known e.g.
 search to find if diabetes is a part of any attribute values:
 """
+
+value = "diabetes"
 search_url = "%S/%s%value=diabetes"
 search_url = "{base_url}{image_value_search}?value={value}".format(
-    base_url=base_url, image_value_search=image_value_search, value="diabetes"
+    base_url=base_url, image_value_search=image_value_search, value=value
 )
 resp = requests.get(url=search_url)
 res = json.loads(resp.text)
-# total items
-logging.info("total_items: %s" % res.get("total_items"))
-logging.info("total_number: %s" % res.get("total_number"))
 # total number of buckets
-logging.info("Number of buckets: %s" % res.get("total_number_of_buckets"))
+logging.info("Total number of buckets: %s" % res.get("total_number_of_buckets"))
 # data
 data = res.get("data")
 logging.info("Number of buckets: %s" % len(data))

--- a/examples/search_for_values_bookmarks.py
+++ b/examples/search_for_values_bookmarks.py
@@ -34,7 +34,7 @@ If the user needs to search for a value whose attribute is not known e.g.
 search to find if diabetes is a part of any attribute values:
 """
 value = "pr"
-search_url = "%S/%s%value=diabetes"
+
 search_url = "{base_url}{image_value_search}?value={value}".format(
     base_url=base_url, image_value_search=image_value_search, value=value
 )
@@ -42,7 +42,6 @@ search_url = "{base_url}{image_value_search}?value={value}".format(
 # url to send the query
 image_value_search = "/resources/image/searchvalues/"
 # searchengine url
-base_url = "http://127.0.0.1:5577/api/v1/"
 logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 
 """

--- a/examples/search_for_values_bookmarks.py
+++ b/examples/search_for_values_bookmarks.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2022 University of Dundee & Open Microscopy Environment.
+# All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import logging
+import json
+import requests
+import sys
+import math
+
+
+# url to send the query
+image_value_search = "/resources/image/searchvalues/"
+# searchengine url
+base_url = "http://127.0.0.1:5577/api/v1/"
+logging.basicConfig(stream=sys.stdout, level=logging.INFO)
+
+"""
+If the user needs to search for a value whose attribute is not known e.g.
+search to find if diabetes is a part of any attribute values:
+"""
+value="pr"
+search_url = "%S/%s%value=diabetes"
+search_url = "{base_url}{image_value_search}?value={value}".format(
+    base_url=base_url, image_value_search=image_value_search, value=value
+)#!/usr/bin/env python
+
+# url to send the query
+image_value_search = "/resources/image/searchvalues/"
+# searchengine url
+base_url = "http://127.0.0.1:5577/api/v1/"
+logging.basicConfig(stream=sys.stdout, level=logging.INFO)
+
+"""
+If the user needs to search for a value whose attribute is not known e.g.
+search to find if p is a part of any attribute values and return all the possible matches:
+"""
+search_url = "{base_url}{image_value_search}?value={value}".format(
+    base_url=base_url, image_value_search=image_value_search, value=value
+)
+resp = requests.get(url=search_url)
+res = json.loads(resp.text)
+# total number of buckets
+# data
+data = res.get("data")
+buckets=[]
+total_number_of_images = 0
+recieved_bukets=0
+buckets=buckets+data
+
+resp = requests.get(url=search_url)
+res = json.loads(resp.text)
+# total number of buckets
+# data
+page=1
+no_pages=math.ceil(res.get("total_number_of_all_buckets")/9999)
+
+logging.info("Total number of images: %s" % res.get("total_number_of_image"))
+logging.info("Total number of returned buckets: %s" % res.get("total_number_of_buckets"))
+logging.info("Total number of all buckets: %s" % res.get("total_number_of_all_buckets"))
+
+bookmark=res.get("bookmark")
+if bookmark:
+    while True:
+        page+=1
+
+        bookmark=[str(item) for item in bookmark]
+        bookmark=','.join(bookmark)
+        search_url = "{base_url}{image_value_search}?value={value}&bookmark={bookmark}".format(
+            base_url=base_url, image_value_search=image_value_search, value=value, bookmark=bookmark
+        )
+        resp = requests.get(url=search_url)
+        try:
+            ss=resp.text
+            res = json.loads(ss)
+        except Exception as e:
+            logging.info("Error %s"%str(e))
+            break
+        bookmark = res.get("bookmark")
+        if not bookmark:
+            break
+        data = res.get("data")
+        buckets = buckets + data
+        logging.info("Page %s/%s" % (page, no_pages))
+        logging.info("Total number of images: %s" % res.get("total_number_of_image"))
+        logging.info("No of buckets: %s" % res.get("total_number_of_buckets"))

--- a/examples/search_for_values_bookmarks.py
+++ b/examples/search_for_values_bookmarks.py
@@ -22,11 +22,11 @@ import json
 import requests
 import sys
 import math
+from utils import base_url
 
 # url to send the query
 image_value_search = "/resources/image/searchvalues/"
 # searchengine url
-base_url = "http://127.0.0.1:5577/api/v1/"
 logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 
 """
@@ -35,10 +35,6 @@ search to find if diabetes is a part of any attribute values:
 """
 value = "pr"
 
-search_url = "{base_url}{image_value_search}?value={value}".format(
-    base_url=base_url, image_value_search=image_value_search, value=value
-)
-
 # url to send the query
 image_value_search = "/resources/image/searchvalues/"
 # searchengine url
@@ -46,7 +42,7 @@ logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 
 """
 If the user needs to search for a value whose attribute is not known
-e.g. search to find if p is a part of any attribute values and return
+e.g. search to find if pr is a part of any attribute values and return
 all the possible matches:
 """
 search_url = "{base_url}{image_value_search}?value={value}".format(

--- a/examples/search_for_values_bookmarks.py
+++ b/examples/search_for_values_bookmarks.py
@@ -23,7 +23,6 @@ import requests
 import sys
 import math
 
-
 # url to send the query
 image_value_search = "/resources/image/searchvalues/"
 # searchengine url
@@ -34,11 +33,11 @@ logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 If the user needs to search for a value whose attribute is not known e.g.
 search to find if diabetes is a part of any attribute values:
 """
-value="pr"
+value = "pr"
 search_url = "%S/%s%value=diabetes"
 search_url = "{base_url}{image_value_search}?value={value}".format(
     base_url=base_url, image_value_search=image_value_search, value=value
-)#!/usr/bin/env python
+)
 
 # url to send the query
 image_value_search = "/resources/image/searchvalues/"
@@ -47,8 +46,9 @@ base_url = "http://127.0.0.1:5577/api/v1/"
 logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 
 """
-If the user needs to search for a value whose attribute is not known e.g.
-search to find if p is a part of any attribute values and return all the possible matches:
+If the user needs to search for a value whose attribute is not known
+e.g. search to find if p is a part of any attribute values and return
+all the possible matches:
 """
 search_url = "{base_url}{image_value_search}?value={value}".format(
     base_url=base_url, image_value_search=image_value_search, value=value
@@ -58,38 +58,45 @@ res = json.loads(resp.text)
 # total number of buckets
 # data
 data = res.get("data")
-buckets=[]
+buckets = []
 total_number_of_images = 0
-recieved_bukets=0
-buckets=buckets+data
+recieved_bukets = 0
+buckets = buckets + data
 
 resp = requests.get(url=search_url)
 res = json.loads(resp.text)
 # total number of buckets
 # data
-page=1
-no_pages=math.ceil(res.get("total_number_of_all_buckets")/9999)
+page = 1
+no_pages = math.ceil(res.get("total_number_of_all_buckets") / 9999)
 
 logging.info("Total number of images: %s" % res.get("total_number_of_image"))
-logging.info("Total number of returned buckets: %s" % res.get("total_number_of_buckets"))
+logging.info(
+    "Total number of returned buckets: %s" % res.get("total_number_of_buckets")
+)
 logging.info("Total number of all buckets: %s" % res.get("total_number_of_all_buckets"))
 
-bookmark=res.get("bookmark")
+bookmark = res.get("bookmark")
 if bookmark:
     while True:
-        page+=1
+        page += 1
 
-        bookmark=[str(item) for item in bookmark]
-        bookmark=','.join(bookmark)
-        search_url = "{base_url}{image_value_search}?value={value}&bookmark={bookmark}".format(
-            base_url=base_url, image_value_search=image_value_search, value=value, bookmark=bookmark
+        bookmark = [str(item) for item in bookmark]
+        bookmark = ",".join(bookmark)
+        search_url = (
+            "{base_url}{image_value_search}?value={value}&bookmark={bookmark}".format(
+                base_url=base_url,
+                image_value_search=image_value_search,
+                value=value,
+                bookmark=bookmark,
+            )
         )
         resp = requests.get(url=search_url)
         try:
-            ss=resp.text
+            ss = resp.text
             res = json.loads(ss)
         except Exception as e:
-            logging.info("Error %s"%str(e))
+            logging.info("Error %s" % str(e))
             break
         bookmark = res.get("bookmark")
         if not bookmark:

--- a/examples/search_values_for_key.py
+++ b/examples/search_values_for_key.py
@@ -21,11 +21,10 @@ import logging
 import requests
 import json
 import sys
+from utils import base_url
 
 # url to send the query
 image_value_search = "/resources/image/searchvalues/"
-# search engine url
-base_url = "http://127.0.0.1:5577/api/v1/"
 logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 # Get the available attributes for a resource, e.g. image
 image_attributes = "/resources/image/keys/"

--- a/examples/search_values_for_key.py
+++ b/examples/search_values_for_key.py
@@ -60,4 +60,5 @@ res = json.loads(resp.text)
 buckets = res.get("data")
 logging.info("Number of available buckets for attribute %s is %s" % (key, len(buckets)))
 # The first bucket
-logging.info("First bucket: %s " % buckets[0])
+for bucket in buckets:
+    logging.info("Bucket details: %s " % bucket)

--- a/examples/search_with_bookmark_paging_using_searchannotation.py
+++ b/examples/search_with_bookmark_paging_using_searchannotation.py
@@ -22,13 +22,12 @@ import json
 import requests
 import sys
 import datetime
+from utils import base_url
 
 # url to send the query
 image_ext = "/resources/image/searchannotation/"
 # url to get the next page for a query, bookmark is needed
 image_page_ext = "/resources/image/searchannotation_page/"
-base_url = "http://127.0.0.1:5577/api/v1/"
-
 
 logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 received_results = []

--- a/examples/search_with_bookmark_paging_using_submitquery.py
+++ b/examples/search_with_bookmark_paging_using_submitquery.py
@@ -22,10 +22,9 @@ import logging
 import json
 import requests
 import sys
+from utils import base_url
 
-# search engine base url
-base_url = "http://127.0.0.1:5577/api/v1/"
-
+# search url
 submit_query_url = f"{base_url}resources/submitquery/"  # noqa
 
 

--- a/examples/search_with_bookmark_paging_using_submitquery.py
+++ b/examples/search_with_bookmark_paging_using_submitquery.py
@@ -116,13 +116,18 @@ bookmark, total_results = call_omero_searchengine_return_results(
     submit_query_url, data=query_data_json
 )
 
+logging.info(
+    "page: %s, / %s received results: %s / %s"
+    % (page, total_pages, len(received_results), total_results)
+)
+
 while len(received_results) < total_results:
 
     page += 1
     query_data_ = {"query_details": {"and_filters": and_filters}, "bookmark": bookmark}
     query_data_json_ = json.dumps(query_data_)
 
-    bookmark, total_results = call_omero_searchengine_return_results(
+    next_bookmark, total_results = call_omero_searchengine_return_results(
         submit_query_url, data=query_data_json_
     )
 
@@ -130,3 +135,4 @@ while len(received_results) < total_results:
         "bookmark: %s, page: %s, / %s received results: %s / %s"
         % (bookmark, page, total_pages, len(received_results), total_results)
     )
+    bookmark=next_bookmark

--- a/examples/search_with_bookmark_paging_using_submitquery.py
+++ b/examples/search_with_bookmark_paging_using_submitquery.py
@@ -135,4 +135,4 @@ while len(received_results) < total_results:
         "bookmark: %s, page: %s, / %s received results: %s / %s"
         % (bookmark, page, total_pages, len(received_results), total_results)
     )
-    bookmark=next_bookmark
+    bookmark = next_bookmark

--- a/examples/search_with_bookmark_paging_using_submitquery.py
+++ b/examples/search_with_bookmark_paging_using_submitquery.py
@@ -23,13 +23,10 @@ import json
 import requests
 import sys
 
-# url to send the query
-image_ext = "/resources/image/searchannotation/"
-# url to get the next page for a query, bookmark is needed
-image_page_ext = "/resources/image/searchannotation_page/"
-# search engine url
+# search engine base url
 base_url = "http://127.0.0.1:5577/api/v1/"
-submit_query_url = "http://127.0.0.1:5577/api/v1/resources/submitquery"  # noqa
+
+submit_query_url = f"{base_url}resources/submitquery/"  # noqa
 
 
 logging.basicConfig(stream=sys.stdout, level=logging.INFO)

--- a/examples/utils.py
+++ b/examples/utils.py
@@ -74,9 +74,8 @@ def query_the_search_ending(query, main_attributes):
     total_pages = returned_results["results"]["total_pages"]
     page = 1
     logging.info(
-        "bookmark: %s, page: %s, received results: %s"
+        "page: %s, received results: %s"
         % (
-            bookmark,
             (str(page) + "/" + str(total_pages)),
             (str(received_results) + "/" + str(total_results)),
         )
@@ -97,7 +96,6 @@ def query_the_search_ending(query, main_attributes):
         except Exception as e:
             logging.info("%s, Error: %s" % (resp.text, e))
             return
-        bookmark = returned_results["results"]["bookmark"]
         received_results = received_results + len(
             returned_results["results"]["results"]
         )
@@ -112,6 +110,7 @@ def query_the_search_ending(query, main_attributes):
                 (str(received_results) + "/" + str(total_results)),
             )
         )
+        bookmark = returned_results["results"]["bookmark"]
 
     logging.info("Total received results: %s" % len(received_results_data))
     return received_results_data

--- a/omero_search_engine/api/v1/resources/query_handler.py
+++ b/omero_search_engine/api/v1/resources/query_handler.py
@@ -158,6 +158,7 @@ class QueryRunner(
         or_query_group,
         case_sensitive,
         bookmark,
+        pagination_dict,
         raw_elasticsearch_query,
         columns_def,
         return_columns,
@@ -167,6 +168,7 @@ class QueryRunner(
         self.and_query_group = and_query_group
         self.case_sensitive = case_sensitive
         self.bookmark = bookmark
+        self.pagination_dict=pagination_dict
         self.columns_def = columns_def
         self.raw_elasticsearch_query = raw_elasticsearch_query
         self.image_query = {}
@@ -333,8 +335,10 @@ class QueryRunner(
         #    return {"Error": "Your query returns no results"}
         if resource == "image":
             bookmark = self.bookmark
+            pagination_dict=self.pagination_dict
         else:
             bookmark = None
+            pagination_dict=None
 
         # res = search_query(query, resource, bookmark,
         #                    self.raw_elasticsearch_query,
@@ -344,13 +348,14 @@ class QueryRunner(
                 query,
                 resource,
                 bookmark,
+                pagination_dict,
                 self.raw_elasticsearch_query,
                 main_attributes,
                 return_containers=self.return_containers,
             )
         else:
             res = search_query(
-                query, resource, bookmark, self.raw_elasticsearch_query, main_attributes
+                query, resource, bookmark,pagination_dict, self.raw_elasticsearch_query, main_attributes
             )
 
         if resource != "image":
@@ -365,6 +370,7 @@ def search_query(
     query,
     resource,
     bookmark,
+    pagination_dict,
     raw_elasticsearch_query,
     main_attributes=None,
     return_containers=False,
@@ -386,14 +392,16 @@ def search_query(
     else:
         q_data = {"query": {"query_details": query, "main_attributes": main_attributes}}
     try:
-        if bookmark:
+        if bookmark or pagination_dict:
             q_data["bookmark"] = bookmark
+            q_data["pagination"] = pagination_dict
             q_data["raw_elasticsearch_query"] = raw_elasticsearch_query
             ress = search_resource_annotation(
                 resource,
                 q_data.get("query"),
                 raw_elasticsearch_query=raw_elasticsearch_query,
                 bookmark=bookmark,
+                pagination_dict=pagination_dict,
                 return_containers=return_containers,
             )
         else:
@@ -551,6 +559,7 @@ def determine_search_results_(query_, return_columns=False, return_containers=Fa
         case_sensitive = False
 
     bookmark = query_.get("bookmark")
+    pagination_dict = query_.get("pagination")
     raw_elasticsearch_query = query_.get("raw_elasticsearch_query")
     and_filters = query_.get("query_details").get("and_filters")
     or_filters = query_.get("query_details").get("or_filters")
@@ -604,6 +613,7 @@ def determine_search_results_(query_, return_columns=False, return_containers=Fa
         or_query_groups,
         case_sensitive,
         bookmark,
+        pagination_dict,
         raw_elasticsearch_query,
         columns_def,
         return_columns,

--- a/omero_search_engine/api/v1/resources/query_handler.py
+++ b/omero_search_engine/api/v1/resources/query_handler.py
@@ -393,7 +393,6 @@ def search_query(
                 resource,
                 q_data.get("query"),
                 raw_elasticsearch_query=raw_elasticsearch_query,
-                page=query.get("page"),
                 bookmark=bookmark,
                 return_containers=return_containers,
             )

--- a/omero_search_engine/api/v1/resources/query_handler.py
+++ b/omero_search_engine/api/v1/resources/query_handler.py
@@ -168,7 +168,7 @@ class QueryRunner(
         self.and_query_group = and_query_group
         self.case_sensitive = case_sensitive
         self.bookmark = bookmark
-        self.pagination_dict=pagination_dict
+        self.pagination_dict = pagination_dict
         self.columns_def = columns_def
         self.raw_elasticsearch_query = raw_elasticsearch_query
         self.image_query = {}
@@ -335,10 +335,10 @@ class QueryRunner(
         #    return {"Error": "Your query returns no results"}
         if resource == "image":
             bookmark = self.bookmark
-            pagination_dict=self.pagination_dict
+            pagination_dict = self.pagination_dict
         else:
             bookmark = None
-            pagination_dict=None
+            pagination_dict = None
 
         # res = search_query(query, resource, bookmark,
         #                    self.raw_elasticsearch_query,
@@ -355,7 +355,12 @@ class QueryRunner(
             )
         else:
             res = search_query(
-                query, resource, bookmark,pagination_dict, self.raw_elasticsearch_query, main_attributes
+                query,
+                resource,
+                bookmark,
+                pagination_dict,
+                self.raw_elasticsearch_query,
+                main_attributes,
             )
 
         if resource != "image":

--- a/omero_search_engine/api/v1/resources/resource_analyser.py
+++ b/omero_search_engine/api/v1/resources/resource_analyser.py
@@ -336,16 +336,18 @@ def prepare_search_results(results, size=0):
         "total_number_of_%s" % (resource): total_number,
         "total_number_of_buckets": number_of_buckets,
     }
-
     if size > 0:
-        results_dict["total_number_of_all_buckets "] = size
+        results_dict["total_number_of_all_buckets"] = size
         if number_of_buckets < size:
             # this should be later to get the next page
-            results_dict["bookmark"] = [
-                int(results["hits"]["hits"][-1]["sort"][0]),
-                int(results["hits"]["hits"][-1]["sort"][1]),
-                results["hits"]["hits"][-1]["sort"][2],
-            ]
+            if len(results["hits"]["hits"]) > 0:
+                results_dict["bookmark"] = [
+                    int(results["hits"]["hits"][-1]["sort"][0]),
+                    int(results["hits"]["hits"][-1]["sort"][1]),
+                    results["hits"]["hits"][-1]["sort"][2],
+                ]
+            else:
+                results_dict["bookmark"] = None
     return results_dict
 
 

--- a/omero_search_engine/api/v1/resources/resource_analyser.py
+++ b/omero_search_engine/api/v1/resources/resource_analyser.py
@@ -475,7 +475,9 @@ def query_cashed_bucket_value(value, es_index="key_value_buckets_information"):
     return prepare_search_results(res)
 
 
-def search_value_for_resource(table_, value, es_index="key_value_buckets_information"):
+def search_value_for_resource(
+    table_, value, bookmarks=None, es_index="key_value_buckets_information"
+):
     """
     send the request to elasticsearch and format the results
     It support wildcard operations only
@@ -492,12 +494,14 @@ def search_value_for_resource(table_, value, es_index="key_value_buckets_informa
         # Get the total number of the results.
         res = search_index_for_value(es_index, size_query, True)
         size = res["count"]
+        # use bookmark is it is provided
+        if bookmarks:
+            query = json.loads(query)
+            query["search_after"] = bookmarks
+
         res = search_index_for_value(es_index, query)
         return prepare_search_results(res, size)
     else:
-        # If the user does not specify anything,
-        # it will add * at the start and at the end to
-        # return all the values which contain the search term
         returned_results = {}
         for table in resource_elasticsearchindex:
             # ignore image1 as it is used for testing
@@ -507,9 +511,14 @@ def search_value_for_resource(table_, value, es_index="key_value_buckets_informa
             query = resource_key_values_buckets_template.substitute(
                 value=value, resource=table
             )
-
+            size_query = resource_key_values_buckets_size_template.substitute(
+                value=value, resource=table_
+            )
+            # Get the total number of the results.
+            res = search_index_for_value(es_index, size_query, True)
+            size = res["count"]
             res = search_index_for_value(es_index, query)
-            returned_results[table] = prepare_search_results(res)
+            returned_results[table] = prepare_search_results(res, size)
         return returned_results
 
 

--- a/omero_search_engine/api/v1/resources/swagger_docs/search_for_any_value.yml
+++ b/omero_search_engine/api/v1/resources/swagger_docs/search_for_any_value.yml
@@ -15,7 +15,7 @@ parameters:
     type: string
     required: true
   - name: bookmark
-    description: search term (should not be used with "all"), a comma-delimited string, e.g. 4,9, 44a90c1a-3271-448a-ba60-c391f885bc34
+    description: search term (should not be used with "all" or key is present), a comma-delimited string, e.g. 4,9, 44a90c1a-3271-448a-ba60-c391f885bc34
     in: query
     type: string
     required: false

--- a/omero_search_engine/api/v1/resources/swagger_docs/search_for_any_value.yml
+++ b/omero_search_engine/api/v1/resources/swagger_docs/search_for_any_value.yml
@@ -14,6 +14,11 @@ parameters:
     in: query
     type: string
     required: true
+  - name: bookmark
+    description: search term (should not be used with "all"), a comma-delimited string, e.g. 4,9, 44a90c1a-3271-448a-ba60-c391f885bc34
+    in: query
+    type: string
+    required: false
   - name: key
     description: search term
     in: query

--- a/omero_search_engine/api/v1/resources/swagger_docs/submitquery.yml
+++ b/omero_search_engine/api/v1/resources/swagger_docs/submitquery.yml
@@ -26,7 +26,8 @@ Example:
     }
 
 
-The maximum number of returned results is 1000, so if the number of results is bigger than that, a bookmark should be added to the query to call the next page. bookmark is returned with each page of results and should be used to call the next page.
+The maximum number of returned results is 1000, so if the number of results is bigger than that, a `bookmark` should be added to the query to call the next page.
+`bookmark` is returned with each page of results and should be used to call the next page.
 Example of using bookmark:
 
   {
@@ -50,6 +51,45 @@ Example of using bookmark:
   [107448]
 
   }
+
+There is a dict (`pagination`)  is returned with results.
+It can be sent back with the query when calling the next page.
+Then the server will update it and send it again along with the results to the client.
+Example of using pagination:
+
+{
+"resource":"image",
+"query_details":{
+"and_filters":[
+{
+"name":"Cell Line",
+"operator":"equals",
+"query_type":"keyvalue",
+"resource":"image",
+"value":"hela"
+}
+],
+"case_sensitive":false,
+"or_filters":[
+
+]
+},
+"pagination": {
+      "current_page": 1,
+      "next_page": 2,
+      "page_records": [
+        {
+          "bookmark": [
+            107448
+          ],
+          "page": 2
+        }
+      ],
+      "total_pages": 1578
+    }
+
+}
+
 ---
 tags:
  - Mixed Complex query

--- a/omero_search_engine/api/v1/resources/urls.py
+++ b/omero_search_engine/api/v1/resources/urls.py
@@ -79,6 +79,7 @@ def search_resource_page(resource_table):
             page = data.get("page")
             bookmark = data.get("bookmark")
             raw_elasticsearch_query = data.get("raw_elasticsearch_query")
+            pagination_dict = data.get("pagination")
             return_containers = data.get("return_containers")
             if return_containers:
                 return_containers = json.loads(return_containers.lower())
@@ -89,6 +90,7 @@ def search_resource_page(resource_table):
                 raw_elasticsearch_query=raw_elasticsearch_query,
                 page=page,
                 bookmark=bookmark,
+                pagination_dict=pagination_dict,
                 return_containers=return_containers,
             )
             return jsonify(resource_list)

--- a/omero_search_engine/api/v1/resources/urls.py
+++ b/omero_search_engine/api/v1/resources/urls.py
@@ -193,8 +193,37 @@ def get_values_using_value(resource_table):
     if key:
         # If the key is provided it will restrict the search to the provided key.
         return query_cashed_bucket_part_value_keys(key, value, resource_table)
-    else:
-        return jsonify(search_value_for_resource(resource_table, value))
+    bookmark = request.args.get("bookmark")
+    if bookmark:
+        bookmark = bookmark.split(",")
+        if bookmark and resource_table == "all":
+            return jsonify(
+                build_error_message(
+                    "{error}".format(
+                        error="Boomark is not supported 'all', "
+                        "it should be used with individual resources"
+                    )
+                )
+            )
+
+        if len(bookmark) != 3:
+            return jsonify(
+                build_error_message(
+                    "{error}".format(
+                        error="Bookmark should be a comma-delimited string, "
+                        "e.g. 4,9,44a90c1a-3271-448a-ba60-c391f885bc34"
+                    )
+                )
+            )
+        if not bookmark[0].isdigit() or not bookmark[1].isdigit():
+            return jsonify(
+                build_error_message(
+                    "{error}".format(
+                        error="The first two items in the bookmark should be intgers"
+                    )
+                )
+            )
+    return jsonify(search_value_for_resource(resource_table, value, bookmark))
 
 
 @resources.route("/<resource_table>/searchvaluesusingkey/", methods=["GET"])

--- a/omero_search_engine/api/v1/resources/urls.py
+++ b/omero_search_engine/api/v1/resources/urls.py
@@ -76,7 +76,6 @@ def search_resource_page(resource_table):
         query = data["query"]
         validation_results = query_validator(query)
         if validation_results == "OK":
-            page = data.get("page")
             bookmark = data.get("bookmark")
             raw_elasticsearch_query = data.get("raw_elasticsearch_query")
             pagination_dict = data.get("pagination")
@@ -88,7 +87,6 @@ def search_resource_page(resource_table):
                 resource_table,
                 query,
                 raw_elasticsearch_query=raw_elasticsearch_query,
-                page=page,
                 bookmark=bookmark,
                 pagination_dict=pagination_dict,
                 return_containers=return_containers,

--- a/omero_search_engine/api/v1/resources/utils.py
+++ b/omero_search_engine/api/v1/resources/utils.py
@@ -747,7 +747,8 @@ def search_index_scrol(index_name, query):
 
 def get_bookmark(pagination_dict):
     """
-    get book mark from the pagination section if the the request does not contain bookmark
+    get book mark from the pagination section
+    if the the request does not contain bookmark
     """
     bookmark = None
     if pagination_dict:
@@ -760,7 +761,7 @@ def get_bookmark(pagination_dict):
     return bookmark
 
 
-def set_pagination(total_pages, next_bookmark, pagination_dict):
+def get_pagination(total_pages, next_bookmark, pagination_dict):
     """
     This keeps track of pages, it can be used to track and lood pages (next by default)
 
@@ -827,6 +828,10 @@ def search_index_using_search_after(
     e_index, query, bookmark_, pagination_dict, return_containers, ret_type=None
 ):
     returned_results = []
+    if bookmark_ and not pagination_dict:
+        add_paination = False
+    else:
+        add_paination = True
 
     es = search_omero_app.config.get("es_connector")
     if return_containers:
@@ -877,14 +882,16 @@ def search_index_using_search_after(
             search_omero_app.logger.info("No result is found")
             return returned_results
         bookmark = [res["hits"]["hits"][-1]["sort"][0]]
-    pagination_dict = set_pagination(no_of_pages, bookmark, pagination_dict)
-    return {
+    results_dict = {
         "results": returned_results,
         "total_pages": no_of_pages,
         "bookmark": bookmark,
         "size": size,
-        "pagination": pagination_dict,
     }
+    if add_paination:
+        pagination_dict = get_pagination(no_of_pages, bookmark, pagination_dict)
+        results_dict["pagination"] = pagination_dict
+    return results_dict
 
 
 def handle_query(table_, query):

--- a/omero_search_engine/api/v1/resources/utils.py
+++ b/omero_search_engine/api/v1/resources/utils.py
@@ -745,6 +745,21 @@ def search_index_scrol(index_name, query):
     return results
 
 
+def mange_pagination(page,total_pages, bookmaek, pagination_dict):
+    '''
+    This add keep track of pages
+    '''
+    if not pagination_dict:
+        pagination_dict={}
+        pagination_dict["total_pages"]=total_pages
+
+    if not pagination_dict.get("page_records"):
+        pagination_dict["page_records"]=[]
+
+    page_records=pagination_dict["page_records"]
+
+    pass
+
 def search_index_using_search_after(
     e_index, query, page, bookmark_, return_containers, ret_type=None
 ):

--- a/omero_search_engine/api/v1/resources/utils.py
+++ b/omero_search_engine/api/v1/resources/utils.py
@@ -745,18 +745,29 @@ def search_index_scrol(index_name, query):
     return results
 
 
-def mange_pagination(page,total_pages, bookmaek, pagination_dict):
+def mange_pagination(page, total_pages, cur_bookmark,next_bookmark, pagination_dict):
     '''
     This add keep track of pages
     '''
     if not pagination_dict:
         pagination_dict={}
         pagination_dict["total_pages"]=total_pages
+        pagination_dict["page_records"] = []
 
     if not pagination_dict.get("page_records"):
         pagination_dict["page_records"]=[]
 
     page_records=pagination_dict["page_records"]
+    cur_page_record={"page":page,"bookmark":next_bookmark}
+    is_it_added = False
+    if len(page_records)>0:
+        for page_record in page_records:
+            if page_record.get("page")==page:
+                is_it_added=True
+                break
+    elif not is_it_added or len(page_records)==0:
+        page_records.append(cur_page_record)
+
 
     pass
 

--- a/omero_search_engine/validation/results_validator.py
+++ b/omero_search_engine/validation/results_validator.py
@@ -234,14 +234,14 @@ class Validator(object):
             else:
                 size = 0
                 ids = []
-                idsp=[]
+                idsp = []
 
                 # get all the results if the total number is bigger
                 # than the page size
             if size >= search_omero_app.config["PAGE_SIZE"] and self.deep_check:
                 bookmark = searchengine_results["results"]["bookmark"]
-                pagination_dict= searchengine_results["results"]["pagination"]
-                ##check getting the results using bookmark
+                pagination_dict = searchengine_results["results"]["pagination"]
+                # check getting the results using bookmark
                 while len(ids) < size:
                     search_omero_app.logger.info(
                         "Received %s/%s" % (len(ids), size)
@@ -256,11 +256,14 @@ class Validator(object):
                     ]
                     ids = ids + ids_
                     bookmark = searchengine_results_["results"]["bookmark"]
-                #check the results using pagination
+                # check the results using pagination
                 query_data_ = {"query_details": query, "bookmark": None}
-                next_page=pagination_dict.get("next_page")
+                next_page = pagination_dict.get("next_page")
                 while next_page:
-                    query_data_ = {"query_details": query, "pagination": pagination_dict}
+                    query_data_ = {
+                        "query_details": query,
+                        "pagination": pagination_dict,
+                    }
                     searchengine_results_ = determine_search_results_(
                         query_data_
                     )  # noqa
@@ -268,19 +271,22 @@ class Validator(object):
                         item["id"]
                         for item in searchengine_results_["results"]["results"]
                     ]
-                    idsp = idsp+ ids_
+                    idsp = idsp + ids_
                     pagination_dict = searchengine_results["results"]["pagination"]
                     next_page = pagination_dict.get("next_page")
-                if len(ids)!=len(idsp):
-                    search_omero_app.logger.info("The results using bookmark (%s)  and the results using pagination (%s) are not equal"%(len(ids),len(idsp)))
+                if len(ids) != len(idsp):
+                    search_omero_app.logger.info(
+                        "The results using bookmark (%s)  and the "
+                        "results using pagination (%s) are not equal"
+                        % (len(ids), len(idsp))
+                    )
 
             self.searchengine_results = {"size": size, "ids": ids, "idsp": idsp}
 
             search_omero_app.logger.info(
-            "no of received results from searchengine  : %s"
-            % self.searchengine_results.get("size")
+                "no of received results from searchengine  : %s"
+                % self.searchengine_results.get("size")
             )
-
 
         else:
             search_omero_app.logger.info("The query is not valid")
@@ -317,8 +323,8 @@ class Validator(object):
             None,
             return_containers=True,
         )
-        print (search_engine_results["results"])
-        print ("======================")
+        print(search_engine_results["results"])
+        print("======================")
         if search_engine_results["results"].get("results"):
             for item in search_engine_results["results"].get("results"):
                 if item["type"] == "screen":
@@ -430,17 +436,27 @@ class Validator(object):
                 "not equal, database no of the results from server is: %s and\
                  the number of results from searchengine (bookmark) is %s?,\
                  \ndatabase server query time= %s, searchengine query time= %s"
-                % (len(self.postgres_results), searchengine_no, sql_time, searchengine_time)
+                % (
+                    len(self.postgres_results),
+                    searchengine_no,
+                    sql_time,
+                    searchengine_time,
+                )
             )
         else:
             return (
-                    "not equal, database no of the results from server is: %s and\
+                "not equal, database no of the results from server is: %s and\
                      the number of results from searchengine (bookmark) is %s?,\
                     the number of results from searchengine (pagination) is %s?,\
                      \ndatabase server query time= %s, searchengine query time= %s"
-                    % (len(self.postgres_results), searchengine_no,len(serach_idsp) ,sql_time, searchengine_time)
+                % (
+                    len(self.postgres_results),
+                    searchengine_no,
+                    len(serach_idsp),
+                    sql_time,
+                    searchengine_time,
+                )
             )
-
 
 
 def validate_queries(json_file, deep_check):

--- a/omero_search_engine/validation/results_validator.py
+++ b/omero_search_engine/validation/results_validator.py
@@ -289,6 +289,8 @@ class Validator(object):
             None,
             return_containers=True,
         )
+        print (search_engine_results["results"])
+        print ("======================")
         if search_engine_results["results"].get("results"):
             for item in search_engine_results["results"].get("results"):
                 if item["type"] == "screen":
@@ -328,7 +330,7 @@ class Validator(object):
             no_results_postgresql = len(screens_results_idr) + len(projects_results_idr)
             if no_results_postgresql == no_results_searchengine:
                 mes = (
-                    "The number of the results from PostgreSQL "
+                    "The number of the results (containers) from PostgreSQL "
                     "and the Searchengine (%s) are equal" % no_results_postgresql
                 )
                 mess.append(mes)


### PR DESCRIPTION
#47 is addressed in this PR.

There is a dict (`pagination`) returned with the results. 

`pagination_dict = returned_results["results"].get("pagination")`

It contains the current page, next page, total pages and page records.
If the next_page is `None` then there is no next page and the current_page is the last page.

It is required to send back the received `pagination` part with the query when calling the next page. Then the server will update it and send it again along with the results to the client.

Then the query should be something like that:
```
{
   "query_details":{
      "and_filters":[
         {
            "name":"Cell Line",
            "value":"hela",
            "operator":"equals",
            "resource":"image"
         },
         {
            "name":"Name (IDR number)",
            "value":"idr0008-rohn-actinome/screenB",
            "operator":"equals",
            "resource":"project"
         }
      ],
      "or_filters":[
         
      ],
      "case_sensitive":false
   },
"pagination": {
      "current_page": 1,
      "next_page": 2,
      "page_records": [
        {
          "bookmark": [
            107448
          ],
          "page": 2
        }
      ],
      "total_pages": 12
    }
}
```
It still supports the `bookmark `in addition to the `pagination`. 

This PR also supports pagination when searching for values without a key using `searchvalues` endpoint. 
As the searchengine restricts the number of the returned results to about 9999 for this endpoint, there was a need for a way to retrieve the remaining results when the number of the results exceeded this number. In such case, the searchengine will return bookmarks which can be used to retrieve the next page of the results.
```
  "bookmark": [
    5,
    9,
    "44a90c1a-3271-448a-ba60-c391f885bc34"
  ]
```
The next page can be called by adding this bookmark to the call, something like that:

http://idr-testing.openmicroscopy.org/searchengine/api/v1/resources/image/searchvalues/?value=p&bookmark=5,2,2C44a90c1a-3271-448a-ba60-c391f885bc34

It has been deployed on `idr-testing`.

@will-moore could you please check it and let me know what do you think?
