### PR TITLE
Search projects& screens using name and description 

### DIFF
--- a/omero_search_engine/api/v1/resources/query_handler.py
+++ b/omero_search_engine/api/v1/resources/query_handler.py
@@ -41,7 +41,11 @@ def check_get_names(idr_):
         idr_ = idr_.strip()
     resource = "project"
     pr_names = get_resource_names("project")
-    act_name = [name["name"] for name in pr_names if idr_ in name["name"]]
+    act_name = [
+        name["name"]
+        for name in pr_names
+        if name["name"] and idr_.lower() in name["name"].lower()
+    ]
     if len(act_name) == 0:
         pr_names = get_resource_names("screen")
         act_name = [name for name in pr_names if idr_ in name]

--- a/omero_search_engine/api/v1/resources/query_handler.py
+++ b/omero_search_engine/api/v1/resources/query_handler.py
@@ -35,7 +35,7 @@ mapping_names = {
 }
 
 
-def check_get_names(idr_,resource):
+def check_get_names(idr_, resource):
     # check the idr name and return the resource and possible values
     if idr_:
         idr_ = idr_.strip()
@@ -46,7 +46,7 @@ def check_get_names(idr_,resource):
             for name in pr_names
             if name["name"] and idr_.lower() in name["name"].lower()
         ]
-    elif resource == "screen" :
+    elif resource == "screen":
         pr_names = get_resource_names("screen")
         act_name = [
             name["name"]
@@ -622,9 +622,9 @@ def determine_search_results_(query_, return_columns=False, return_containers=Fa
                 for filter in filters_:
                     q_item = QueryItem(filter)
                     if (
-                            q_item.query_type == "main_attribute"
-                            and isinstance(q_item.value, list)
-                            and filter["name"] == "Name (IDR number)"
+                        q_item.query_type == "main_attribute"
+                        and isinstance(q_item.value, list)
+                        and filter["name"] == "Name (IDR number)"
                     ):
                         new_or_filter = []
                         if not or_filters:

--- a/omero_search_engine/api/v1/resources/query_handler.py
+++ b/omero_search_engine/api/v1/resources/query_handler.py
@@ -84,13 +84,18 @@ class QueryItem(object):
         # to use the actual attribute name
         if mapping_names.get(self.resource):
             if mapping_names[self.resource].get(self.name):
-                ac_value, act_res = check_get_names(self.value)
-                if len(ac_value) == 1:
-                    self.value = ac_value[0]
-                elif len(ac_value) > 1:
-                    self.value = ac_value
-                self.resource = act_res
                 self.name = "name"
+                if self.operator == "contains" or self.operator == "not_contains":
+                    ac_value, act_res = check_get_names(self.value)
+                    if len(ac_value) == 1:
+                        self.value = ac_value[0]
+                    elif len(ac_value) > 1:
+                        self.value = ac_value
+                    self.resource = act_res
+                    if self.operator == "contains":
+                        self.operator = "equals"
+                    else:
+                        self.operator = "not_equals"
                 """
                 pr_names = get_resource_names(self.resource)
                 if not self.value in pr_names:

--- a/omero_search_engine/api/v1/resources/query_handler.py
+++ b/omero_search_engine/api/v1/resources/query_handler.py
@@ -579,6 +579,8 @@ def process_search_results(results, resource, columns_def):
 
 
 def determine_search_results_(query_, return_columns=False, return_containers=False):
+    from omero_search_engine.api.v1.resources.utils import build_error_message
+
     if query_.get("query_details"):
         case_sensitive = query_.get("query_details").get("case_sensitive")
     else:
@@ -601,7 +603,13 @@ def determine_search_results_(query_, return_columns=False, return_containers=Fa
             # Please note it is working for and filter when there is not
             # identical match for the idr name
             if q_item.query_type == "main_attribute" and (
-                filter["name"] == "name" or filter["name"] == "description"
+                filter["name"] == "description"
+            ):
+                return build_error_message(
+                    "This release does not support search by description."
+                )
+            if q_item.query_type == "main_attribute" and (
+                filter["name"] == "name"  # or filter["name"] == "description"
             ):
                 if isinstance(q_item.value, list):
                     new_or_filter = []
@@ -633,7 +641,13 @@ def determine_search_results_(query_, return_columns=False, return_containers=Fa
                 for filter in filters_:
                     q_item = QueryItem(filter)
                     if q_item.query_type == "main_attribute" and (
-                        filter["name"] == "name" or filter["name"] == "description"
+                        filter["name"] == "description"
+                    ):
+                        return build_error_message(
+                            "This release does not support search by description."
+                        )
+                    if q_item.query_type == "main_attribute" and (
+                        filter["name"] == "name"  # or filter["name"] == "description"
                     ):
                         if isinstance(q_item.value, list):
                             for val in q_item.value:

--- a/omero_search_engine/api/v1/resources/query_handler.py
+++ b/omero_search_engine/api/v1/resources/query_handler.py
@@ -90,7 +90,9 @@ class QueryItem(object):
                 self.name = mapping_names[self.resource].get(self.name)
                 if self.operator == "contains" or self.operator == "not_contains":
                     ac_value = check_get_names(self.value, self.resource, self.name)
-                    if len(ac_value) == 1:
+                    if len(ac_value) == 0:
+                        self.value = -1
+                    elif len(ac_value) == 1:
                         self.value = ac_value[0]
                     elif len(ac_value) > 1:
                         self.value = ac_value

--- a/omero_search_engine/api/v1/resources/query_handler.py
+++ b/omero_search_engine/api/v1/resources/query_handler.py
@@ -41,7 +41,7 @@ def check_get_names(idr_):
         idr_ = idr_.strip()
     resource = "project"
     pr_names = get_resource_names("project")
-    act_name = [name for name in pr_names if idr_ in name]
+    act_name = [name["name"] for name in pr_names if idr_ in name["name"]]
     if len(act_name) == 0:
         pr_names = get_resource_names("screen")
         act_name = [name for name in pr_names if idr_ in name]

--- a/omero_search_engine/api/v1/resources/query_handler.py
+++ b/omero_search_engine/api/v1/resources/query_handler.py
@@ -626,10 +626,6 @@ def determine_search_results_(query_, return_columns=False, return_containers=Fa
                         and isinstance(q_item.value, list)
                         and filter["name"] == "name"
                     ):
-                        new_or_filter = []
-                        if not or_filters:
-                            or_filters = []
-                        or_filters.append(new_or_filter)
                         for val in q_item.value:
                             new_fil = {}
                             new_fil["value"] = val
@@ -638,9 +634,10 @@ def determine_search_results_(query_, return_columns=False, return_containers=Fa
                             new_fil["operator"] = filter["operator"]
                             new_fil["set_query_type"] = True
                             new_fil["query_type"] = q_item.query_type
-                            new_or_filter.append(new_fil)
+                            _q_item = QueryItem(new_fil)
+                            or_query_group.add_query(_q_item)
                     else:
-                        or_query_group.add_query((q_item))
+                        or_query_group.add_query(q_item)
             or_query_group.divide_filter()
             or_query_group.adjust_query_main_attributes()
 

--- a/omero_search_engine/api/v1/resources/query_handler.py
+++ b/omero_search_engine/api/v1/resources/query_handler.py
@@ -594,7 +594,7 @@ def determine_search_results_(query_, return_columns=False, return_containers=Fa
             if (
                 q_item.query_type == "main_attribute"
                 and isinstance(q_item.value, list)
-                and filter["name"] == "Name (IDR number)"
+                and filter["name"] == "name"
             ):
                 new_or_filter = []
                 if not or_filters:
@@ -624,7 +624,7 @@ def determine_search_results_(query_, return_columns=False, return_containers=Fa
                     if (
                         q_item.query_type == "main_attribute"
                         and isinstance(q_item.value, list)
-                        and filter["name"] == "Name (IDR number)"
+                        and filter["name"] == "name"
                     ):
                         new_or_filter = []
                         if not or_filters:

--- a/omero_search_engine/api/v1/resources/query_handler.py
+++ b/omero_search_engine/api/v1/resources/query_handler.py
@@ -30,31 +30,23 @@ import os
 from urllib.parse import urljoin
 
 mapping_names = {
-    "project": {"Name (IDR number)": "name"},
-    "screen": {"Name (IDR number)": "name"},
+    "project": {"Name (IDR number)": "name", "description": "description"},
+    "screen": {"Name (IDR number)": "name", "description": "description"},
 }
 
 
-def check_get_names(idr_, resource):
+def check_get_names(idr_, resource, attribute):
     # check the idr name and return the resource and possible values
     if idr_:
         idr_ = idr_.strip()
-    if resource == "project":
-        pr_names = get_resource_names("project")
+    pr_names = get_resource_names(resource)
+    if pr_names:
         act_name = [
-            name["name"]
+            name[attribute]
             for name in pr_names
-            if name["name"] and idr_.lower() in name["name"].lower()
+            if name[attribute] and idr_.lower() in name[attribute].lower()
         ]
-    elif resource == "screen":
-        pr_names = get_resource_names("screen")
-        act_name = [
-            name["name"]
-            for name in pr_names
-            if name["name"] and idr_.lower() in name["name"].lower()
-        ]
-
-    return act_name
+        return act_name
 
 
 class QueryItem(object):
@@ -88,9 +80,9 @@ class QueryItem(object):
         # to use the actual attribute name
         if mapping_names.get(self.resource):
             if mapping_names[self.resource].get(self.name):
-                self.name = "name"
+                self.name = mapping_names[self.resource].get(self.name)
                 if self.operator == "contains" or self.operator == "not_contains":
-                    ac_value = check_get_names(self.value, self.resource)
+                    ac_value = check_get_names(self.value, self.resource, self.name)
                     if len(ac_value) == 1:
                         self.value = ac_value[0]
                     elif len(ac_value) > 1:

--- a/omero_search_engine/api/v1/resources/query_handler.py
+++ b/omero_search_engine/api/v1/resources/query_handler.py
@@ -43,7 +43,7 @@ def check_get_names(idr_, resource, attribute, return_exact=False):
     if pr_names:
         if not return_exact:
             act_name = [
-                name[attribute]
+                name["id"]
                 for name in pr_names
                 if name[attribute] and idr_.lower() in name[attribute].lower()
             ]

--- a/omero_search_engine/api/v1/resources/resource_analyser.py
+++ b/omero_search_engine/api/v1/resources/resource_analyser.py
@@ -736,7 +736,7 @@ def get_resource_attribute_values(
 def get_resource_names(resource, name=None, es_index="key_values_resource_cach"):
     """
     return resources names attributes
-    It works for projects and screens.
+    It works for projects and screens but can be extended.
     """
     if not name:
         query = key_values_buckets_template_2.substitute(resource=resource)

--- a/omero_search_engine/api/v1/resources/resource_analyser.py
+++ b/omero_search_engine/api/v1/resources/resource_analyser.py
@@ -739,17 +739,17 @@ def get_resource_names(resource, name=None, description=False):
     It works for projects and screens but can be extended.
     """
     if resource != "all":
-        returned_results = get_the_results(resource, name,description)
+        returned_results = get_the_results(resource, name, description)
     else:
         returned_results = {}
         ress = ["project", "screen"]
         for res in ress:
-            returned_results[res] = get_the_results(res, name,description)
+            returned_results[res] = get_the_results(res, name, description)
 
     return returned_results
 
 
-def get_the_results(resource, name,description, es_index="key_values_resource_cach"):
+def get_the_results(resource, name, description, es_index="key_values_resource_cach"):
     returned_results = {}
     query = key_values_buckets_template_2.substitute(resource=resource)
     results_ = connect_elasticsearch(
@@ -765,10 +765,14 @@ def get_the_results(resource, name,description, es_index="key_values_resource_ca
             ]
         elif name and description:
             returned_results = {
-                item: value for item, value in hits[0]["_source"]["resourcename"].items() if name in item
+                item: value
+                for item, value in hits[0]["_source"]["resourcename"].items()
+                if name in item
             }
             returned_results_1 = {
-                item: value for item, value in hits[0]["_source"]["resourcename"].items() if value and name in value
+                item: value
+                for item, value in hits[0]["_source"]["resourcename"].items()
+                if value and name in value
             }
             for item, value in returned_results_1.items():
                 if item not in returned_results:

--- a/omero_search_engine/api/v1/resources/resource_analyser.py
+++ b/omero_search_engine/api/v1/resources/resource_analyser.py
@@ -599,6 +599,13 @@ key_values_buckets_template_2 = Template(
 "resource.keyresource":"$resource"}}}}]}}} """
 )
 
+key_values_buckets_template_search_name = Template(
+    """
+{"query":{"bool":{"must":[{"bool":{"must":{"match":{
+"resource.keyresource":"$resource"}}}},{"bool": {"must":
+{"wildcard": {"resourcename.keyresourcename":"*$name*"}}}}]}}} """
+)
+
 
 def connect_elasticsearch(es_index, query, count=False):
     es = search_omero_app.config.get("es_connector")
@@ -723,30 +730,39 @@ def get_resource_attribute_values(
     return returned_results
 
 
-def get_resource_names(resource, es_index="key_values_resource_cach"):
+def get_resource_names(resource, name=None,es_index="key_values_resource_cach"):
     """
     return resources names attributes
-    It works for projects and screens but can be extended.
+    It works for projects and screens.
     """
-    returned_results = []
-    if resource != "all":
+    if not name:
         query = key_values_buckets_template_2.substitute(resource=resource)
+    else:
+        query = key_values_buckets_template_search_name.substitute(resource=resource, name=name)
+    if resource != "all":
+        returned_results = []
         results_ = connect_elasticsearch(
             es_index, query
         )  # .search(index=es_index, body=query)
         hits = results_["hits"]["hits"]
         if len(hits) > 0:
-            returned_results = hits[0]["_source"]["resourcename"]
+            if name:
+                returned_results = [item for item in hits[0]["_source"]["resourcename"] if name in item]
+            else:
+                returned_results = hits[0]["_source"]["resourcename"]
     else:
+        returned_results = {}
         ress = ["project", "screen"]
         for res in ress:
             query = key_values_buckets_template_2.substitute(resource=res)
             results_ = connect_elasticsearch(
                 es_index, query
             )  # .search(index=es_index, body=query)
-            if len(results_["hits"]["hits"]) > 0:
-                returned_results = (
-                    returned_results
-                    + results_["hits"]["hits"][0]["_source"]["resourcename"]
-                )
+            hits = results_["hits"]["hits"]
+            if len(hits) > 0:
+                if not name:
+                    returned_results[res]= hits[0]["_source"]["resourcename"]
+                else:
+                    returned_results[res]= [item for item in hits[0]["_source"]["resourcename"] if name in item]
+
     return returned_results

--- a/omero_search_engine/api/v1/resources/resource_analyser.py
+++ b/omero_search_engine/api/v1/resources/resource_analyser.py
@@ -749,6 +749,11 @@ def get_resource_names(resource, name=None, description=False):
     return resources names attributes
     It works for projects and screens but can be extended.
     """
+    if description:
+        return build_error_message(
+            "This release does not support search by description."
+        )
+
     if resource != "all":
         returned_results = get_the_results(resource, name, description)
     else:

--- a/omero_search_engine/api/v1/resources/resource_analyser.py
+++ b/omero_search_engine/api/v1/resources/resource_analyser.py
@@ -794,4 +794,10 @@ def get_the_results(resource, name, description, es_index="key_values_resource_c
         else:
             returned_results = [item for item in hits[0]["_source"]["resourcename"]]
 
+    # remove container description from the results,
+    # should be added again later after cleaning up the description
+
+    for item in returned_results:
+        del item["description"]
+
     return returned_results

--- a/omero_search_engine/api/v1/resources/resource_analyser.py
+++ b/omero_search_engine/api/v1/resources/resource_analyser.py
@@ -774,14 +774,17 @@ def get_the_results(resource, name, description, es_index="key_values_resource_c
             returned_results = [
                 item
                 for item in hits[0]["_source"]["resourcename"]
-                if name.lower() in item.get("name").lower()
+                if item.get("name") and name.lower() in item.get("name").lower()
             ]
         elif name and description:
             returned_results = [
                 item
                 for item in hits[0]["_source"]["resourcename"]
-                if name.lower() in item.get("name").lower()
-                or name.lower() in item.get("description").lower()
+                if (item.get("name") and name.lower() in item.get("name").lower())
+                or (
+                    item.get("description")
+                    and name.lower() in item.get("description").lower()
+                )
             ]
         else:
             returned_results = [item for item in hits[0]["_source"]["resourcename"]]

--- a/omero_search_engine/api/v1/resources/resource_analyser.py
+++ b/omero_search_engine/api/v1/resources/resource_analyser.py
@@ -442,6 +442,9 @@ def query_cashed_bucket_part_value_keys(
         # search all resources for all possible matches
         returned_results = {}
         for table in resource_elasticsearchindex:
+            # exclude image1 as it is used for testing
+            if table == "image1":
+                continue
             query = key_part_values_buckets_template.substitute(
                 name=name, value=value, resource=table
             )

--- a/omero_search_engine/api/v1/resources/resource_analyser.py
+++ b/omero_search_engine/api/v1/resources/resource_analyser.py
@@ -730,7 +730,7 @@ def get_resource_attribute_values(
     return returned_results
 
 
-def get_resource_names(resource, name=None,es_index="key_values_resource_cach"):
+def get_resource_names(resource, name=None, es_index="key_values_resource_cach"):
     """
     return resources names attributes
     It works for projects and screens.
@@ -738,7 +738,9 @@ def get_resource_names(resource, name=None,es_index="key_values_resource_cach"):
     if not name:
         query = key_values_buckets_template_2.substitute(resource=resource)
     else:
-        query = key_values_buckets_template_search_name.substitute(resource=resource, name=name)
+        query = key_values_buckets_template_search_name.substitute(
+            resource=resource, name=name
+        )
     if resource != "all":
         returned_results = []
         results_ = connect_elasticsearch(
@@ -747,7 +749,9 @@ def get_resource_names(resource, name=None,es_index="key_values_resource_cach"):
         hits = results_["hits"]["hits"]
         if len(hits) > 0:
             if name:
-                returned_results = [item for item in hits[0]["_source"]["resourcename"] if name in item]
+                returned_results = [
+                    item for item in hits[0]["_source"]["resourcename"] if name in item
+                ]
             else:
                 returned_results = hits[0]["_source"]["resourcename"]
     else:
@@ -761,8 +765,12 @@ def get_resource_names(resource, name=None,es_index="key_values_resource_cach"):
             hits = results_["hits"]["hits"]
             if len(hits) > 0:
                 if not name:
-                    returned_results[res]= hits[0]["_source"]["resourcename"]
+                    returned_results[res] = hits[0]["_source"]["resourcename"]
                 else:
-                    returned_results[res]= [item for item in hits[0]["_source"]["resourcename"] if name in item]
+                    returned_results[res] = [
+                        item
+                        for item in hits[0]["_source"]["resourcename"]
+                        if name in item
+                    ]
 
     return returned_results

--- a/omero_search_engine/api/v1/resources/resource_analyser.py
+++ b/omero_search_engine/api/v1/resources/resource_analyser.py
@@ -772,23 +772,18 @@ def get_the_results(resource, name, description, es_index="key_values_resource_c
         # print (hits[0]["_source"])
         if name and not description:
             returned_results = [
-                item for item in hits[0]["_source"]["resourcename"] if name.lower() in item.lower()
+                item
+                for item in hits[0]["_source"]["resourcename"]
+                if name.lower() in item.get("name").lower()
             ]
         elif name and description:
-            returned_results = {
-                item: value
-                for item, value in hits[0]["_source"]["resourcename"].items()
-                if name.lower() in item.lower()
-            }
-            returned_results_1 = {
-                item: value
-                for item, value in hits[0]["_source"]["resourcename"].items()
-                if value and name in value
-            }
-            for item, value in returned_results_1.items():
-                if item not in returned_results:
-                    returned_results[item] = value
-
+            returned_results = [
+                item
+                for item in hits[0]["_source"]["resourcename"]
+                if name.lower() in item.get("name").lower()
+                or name.lower() in item.get("description").lower()
+            ]
         else:
-            returned_results = list(hits[0]["_source"]["resourcename"].keys())
+            returned_results = [item for item in hits[0]["_source"]["resourcename"]]
+
     return returned_results

--- a/omero_search_engine/api/v1/resources/resource_analyser.py
+++ b/omero_search_engine/api/v1/resources/resource_analyser.py
@@ -772,13 +772,13 @@ def get_the_results(resource, name, description, es_index="key_values_resource_c
         # print (hits[0]["_source"])
         if name and not description:
             returned_results = [
-                item for item in hits[0]["_source"]["resourcename"] if name in item
+                item for item in hits[0]["_source"]["resourcename"] if name.lower() in item.lower()
             ]
         elif name and description:
             returned_results = {
                 item: value
                 for item, value in hits[0]["_source"]["resourcename"].items()
-                if name in item
+                if name.lower() in item.lower()
             }
             returned_results_1 = {
                 item: value

--- a/omero_search_engine/api/v1/resources/schemas/filter_schema.json
+++ b/omero_search_engine/api/v1/resources/schemas/filter_schema.json
@@ -23,8 +23,7 @@
      ,"resource": {
       "name": "resource",
       "type": "string",
-      "enum": ["image", "screen", "project","study","plate"]
+      "enum": ["image", "screen", "project","plate","well"]
     }
     }
   }
-

--- a/omero_search_engine/api/v1/resources/swagger_docs/getresourcenames.yml
+++ b/omero_search_engine/api/v1/resources/swagger_docs/getresourcenames.yml
@@ -6,8 +6,12 @@ parameters:
   - name: resource_table
     in: path
     type: string
-    enum: ['project', 'screen']
+    enum: ['all','project', 'screen']
     required: true
+  - name: value
+    in: query
+    type: string
+    required: false
 definitions:
   names:
     type: array

--- a/omero_search_engine/api/v1/resources/urls.py
+++ b/omero_search_engine/api/v1/resources/urls.py
@@ -191,7 +191,7 @@ def get_values_using_value(resource_table):
     # print (value, resource_table)
     key = request.args.get("key")
     if key:
-
+        # If the key is provided it will restrict the search to the provided key.
         return jsonify(query_cashed_bucket_part_value_keys(key, value, resource_table))
 
     else:

--- a/omero_search_engine/api/v1/resources/urls.py
+++ b/omero_search_engine/api/v1/resources/urls.py
@@ -191,17 +191,9 @@ def get_values_using_value(resource_table):
     # print (value, resource_table)
     key = request.args.get("key")
     if key:
-        # If the key is provided it will restrict the search to the provided key.
-        if (key != "name" and key != "Name (IDR number)") and resource_table not in [
-            "all",
-            "project",
-            "screen",
-        ]:
-            return jsonify(
-                query_cashed_bucket_part_value_keys(key, value, resource_table)
-            )
-        else:
-            return jsonify(get_resource_names(resource_table, value))
+
+        return jsonify(query_cashed_bucket_part_value_keys(key, value, resource_table))
+
     else:
         return jsonify(search_value_for_resource(resource_table, value))
 
@@ -276,8 +268,8 @@ def get_resource_names_(resource_table):
         response.mimetype = "text/plain"
         return response
 
-    names = get_resource_names(resource_table)
-    return jsonify(names)
+    value = request.args.get("value")
+    return jsonify(get_resource_names(resource_table, value))
 
 
 @resources.route("/submitquery/containers/", methods=["POST"])

--- a/omero_search_engine/api/v1/resources/urls.py
+++ b/omero_search_engine/api/v1/resources/urls.py
@@ -192,7 +192,10 @@ def get_values_using_value(resource_table):
     key = request.args.get("key")
     if key:
         # If the key is provided it will restrict the search to the provided key.
-        return query_cashed_bucket_part_value_keys(key, value, resource_table)
+        if (key !="name" and key !="Name (IDR number)") and resource_table not in ["all", "project", "screen"]:
+            return jsonify(query_cashed_bucket_part_value_keys(key, value, resource_table))
+        else:
+            return jsonify(get_resource_names(resource_table, value))
     else:
         return jsonify(search_value_for_resource(resource_table, value))
 

--- a/omero_search_engine/api/v1/resources/urls.py
+++ b/omero_search_engine/api/v1/resources/urls.py
@@ -192,8 +192,14 @@ def get_values_using_value(resource_table):
     key = request.args.get("key")
     if key:
         # If the key is provided it will restrict the search to the provided key.
-        if (key !="name" and key !="Name (IDR number)") and resource_table not in ["all", "project", "screen"]:
-            return jsonify(query_cashed_bucket_part_value_keys(key, value, resource_table))
+        if (key != "name" and key != "Name (IDR number)") and resource_table not in [
+            "all",
+            "project",
+            "screen",
+        ]:
+            return jsonify(
+                query_cashed_bucket_part_value_keys(key, value, resource_table)
+            )
         else:
             return jsonify(get_resource_names(resource_table, value))
     else:

--- a/omero_search_engine/api/v1/resources/urls.py
+++ b/omero_search_engine/api/v1/resources/urls.py
@@ -269,14 +269,14 @@ def get_resource_names_(resource_table):
         return response
 
     value = request.args.get("value")
-    description=request.args.get("use_description")
+    description = request.args.get("use_description")
     if description:
         if description.lower() in ["true", "false"]:
-            description=json.loads(description.lower())
-        elif description=='1':
+            description = json.loads(description.lower())
+        elif description == "1":
             description = True
         else:
-            description=False
+            description = False
     return jsonify(get_resource_names(resource_table, value, description))
 
 

--- a/omero_search_engine/api/v1/resources/urls.py
+++ b/omero_search_engine/api/v1/resources/urls.py
@@ -269,7 +269,15 @@ def get_resource_names_(resource_table):
         return response
 
     value = request.args.get("value")
-    return jsonify(get_resource_names(resource_table, value))
+    description=request.args.get("use_description")
+    if description:
+        if description.lower() in ["true", "false"]:
+            description=json.loads(description.lower())
+        elif description=='1':
+            description = True
+        else:
+            description=False
+    return jsonify(get_resource_names(resource_table, value, description))
 
 
 @resources.route("/submitquery/containers/", methods=["POST"])

--- a/omero_search_engine/api/v1/resources/utils.py
+++ b/omero_search_engine/api/v1/resources/utils.py
@@ -960,8 +960,8 @@ def search_resource_annotation(
             if isinstance(query_string, dict):
                 return query_string
 
-            search_omero_app.logger.info("Query %s" % query_string, strict=False)
-            query = json.loads(query_string)
+            search_omero_app.logger.info("Query %s" % query_string)
+            query = json.loads(query_string, strict=False)
             raw_query_to_send_back = json.loads(query_string, strict=False)
         else:
             query = raw_elasticsearch_query

--- a/omero_search_engine/api/v1/resources/utils.py
+++ b/omero_search_engine/api/v1/resources/utils.py
@@ -960,9 +960,9 @@ def search_resource_annotation(
             if isinstance(query_string, dict):
                 return query_string
 
-            search_omero_app.logger.info("Query %s" % query_string)
+            search_omero_app.logger.info("Query %s" % query_string, strict=False)
             query = json.loads(query_string)
-            raw_query_to_send_back = json.loads(query_string)
+            raw_query_to_send_back = json.loads(query_string, strict=False)
         else:
             query = raw_elasticsearch_query
             raw_query_to_send_back = copy.copy(raw_elasticsearch_query)

--- a/omero_search_engine/api/v1/resources/utils.py
+++ b/omero_search_engine/api/v1/resources/utils.py
@@ -195,7 +195,10 @@ def elasticsearch_query_builder(
             for clause in main_attributes.get("and_main_attributes"):
                 if isinstance(clause, list):
                     for attribute in clause:
-                        if attribute["name"].endswith("_id"):
+                        if (
+                            attribute["name"].endswith("_id")
+                            or attribute["name"] == "id"
+                        ):
                             main_dd = (
                                 main_attribute_query_template_id.substitute(  # noqa
                                     attribute=attribute["name"].strip(),
@@ -213,7 +216,7 @@ def elasticsearch_query_builder(
                             nested_must_not_part.append(main_dd)
                 else:
                     attribute = clause
-                    if attribute["name"].endswith("_id"):
+                    if attribute["name"].endswith("_id") or attribute["name"] == "id":
                         main_dd = main_attribute_query_template_id.substitute(
                             attribute=attribute["name"].strip(),
                             value=str(attribute["value"]).strip(),
@@ -239,7 +242,10 @@ def elasticsearch_query_builder(
                 if isinstance(attributes, list):
                     for attribute in attributes:
                         # search using id, e.g. project id
-                        if attribute["name"].endswith("_id"):
+                        if (
+                            attribute["name"].endswith("_id")
+                            or attribute["name"] == "id"
+                        ):
                             main_dd = (
                                 main_attribute_query_template_id.substitute(  # noqa
                                     attribute=attribute["name"].strip(),
@@ -259,7 +265,7 @@ def elasticsearch_query_builder(
                 else:
                     attribute = attributes
                     # search using id, e.g. project id
-                    if attribute["name"].endswith("_id"):
+                    if attribute["name"].endswith("_id") or attribute["name"] == "id":
                         main_dd = main_attribute_query_template_id.substitute(
                             attribute=attribute["name"].strip(),
                             value=str(attribute["value"]).strip(),

--- a/omero_search_engine/api/v1/resources/utils.py
+++ b/omero_search_engine/api/v1/resources/utils.py
@@ -264,16 +264,18 @@ def elasticsearch_query_builder(
                             attribute=attribute["name"].strip(),
                             value=str(attribute["value"]).strip(),
                         )
+
                     else:
                         main_dd = main_attribute_query_template.substitute(
                             attribute=attribute["name"].strip(),
                             value=str(attribute["value"]).strip(),
                         )
+                    sh.append(main_dd)
 
-                    if attribute["operator"].strip() == "equals":
-                        sh.append(main_dd)
-                    elif attribute["operator"].strip() == "not_equals":
-                        sh.append(main_dd)
+                    #if attribute["operator"].strip() == "equals":
+                    #    sh.append(main_dd)
+                    #elif attribute["operator"].strip() == "not_equals":
+                    #    sh.append(main_dd)
 
             # if len(should_part_list)>0:
             #    minimum_should_match=len(should_part_list)

--- a/omero_search_engine/api/v1/resources/utils.py
+++ b/omero_search_engine/api/v1/resources/utils.py
@@ -1035,7 +1035,7 @@ def get_studies_titles(idr_name, resource):
         study_title["id"] = item_.get("id")
         study_title["name"] = item_.get("name")
         study_title["type"] = resource
-        study_title["description"] = item_.get("description")
+        # study_title["description"] = item_.get("description")
         for value in item_.get("key_values"):
             if value.get("name"):
                 value["key"] = value["name"]

--- a/omero_search_engine/api/v1/resources/utils.py
+++ b/omero_search_engine/api/v1/resources/utils.py
@@ -272,9 +272,9 @@ def elasticsearch_query_builder(
                         )
                     sh.append(main_dd)
 
-                    #if attribute["operator"].strip() == "equals":
+                    # if attribute["operator"].strip() == "equals":
                     #    sh.append(main_dd)
-                    #elif attribute["operator"].strip() == "not_equals":
+                    # elif attribute["operator"].strip() == "not_equals":
                     #    sh.append(main_dd)
 
             # if len(should_part_list)>0:

--- a/omero_search_engine/cache_functions/elasticsearch/elasticsearch_templates.py
+++ b/omero_search_engine/cache_functions/elasticsearch/elasticsearch_templates.py
@@ -241,8 +241,8 @@ key_values_resource_cache_template = {
                 "fields": {"keyname": {"type": "keyword"}},
             },  # noqa
             "resourcename": {
-                "type": "text",
-                "fields": {"keyresourcename": {"type": "keyword"}},
+                "type": "object",
+                "enabled": False
             },
         }
     }

--- a/omero_search_engine/cache_functions/elasticsearch/elasticsearch_templates.py
+++ b/omero_search_engine/cache_functions/elasticsearch/elasticsearch_templates.py
@@ -240,10 +240,7 @@ key_values_resource_cache_template = {
                 "type": "text",
                 "fields": {"keyname": {"type": "keyword"}},
             },  # noqa
-            "resourcename": {
-                "type": "object",
-                "enabled": False
-            },
+            "resourcename": {"type": "object", "enabled": False},
         }
     }
 }

--- a/omero_search_engine/cache_functions/elasticsearch/sql_to_csv.py
+++ b/omero_search_engine/cache_functions/elasticsearch/sql_to_csv.py
@@ -35,8 +35,8 @@ screen.id as screen_id, screen.name as screen_name,
 plate.id as plate_id, plate.name as plate_name,
 well.id as well_id,wellsample.id as wellsample_id
 from image
-inner join imageannotationlink on image.id =imageannotationlink.parent
-inner join annotation_mapvalue on
+left join imageannotationlink on image.id =imageannotationlink.parent
+left join annotation_mapvalue on
 annotation_mapvalue.annotation_id=imageannotationlink.child
 left join datasetimagelink on datasetimagelink.child=image.id
 left join dataset on datasetimagelink.parent=dataset.id
@@ -68,8 +68,8 @@ select plate.id, plate.owner_id, plate.group_id,plate.description,
 plate.name as name, annotation_mapvalue.name as mapvalue_name,
 annotation_mapvalue.value as mapvalue_value,
 annotation_mapvalue.index as mapvalue_index from plate
-inner join plateannotationlink on plate.id=plateannotationlink.parent
-inner join annotation_mapvalue on
+left join plateannotationlink on plate.id=plateannotationlink.parent
+left join annotation_mapvalue on
 annotation_mapvalue.annotation_id=plateannotationlink.child
 $whereclause
 GROUP BY plate.id, annotation_mapvalue.index,
@@ -89,8 +89,8 @@ project.name as name, annotation_mapvalue.name as mapvalue_name,
 annotation_mapvalue.value as mapvalue_value,
 annotation_mapvalue.index as mapvalue_index
 from project
-inner join projectannotationlink on project.id =projectannotationlink.parent
-inner join annotation_mapvalue on
+left join projectannotationlink on project.id =projectannotationlink.parent
+left join annotation_mapvalue on
 annotation_mapvalue.annotation_id=projectannotationlink.child
 $whereclause
 GROUP BY project.id, annotation_mapvalue.index,
@@ -111,8 +111,8 @@ screen.name as name,screen.description,
 annotation_mapvalue.name as mapvalue_name,
 annotation_mapvalue.value as mapvalue_value,
 annotation_mapvalue.index as mapvalue_index from screen
-inner join screenannotationlink on screen.id =screenannotationlink.parent
-inner join annotation_mapvalue on
+left join screenannotationlink on screen.id =screenannotationlink.parent
+left join annotation_mapvalue on
 annotation_mapvalue.annotation_id=screenannotationlink.child
 $whereclause
 GROUP BY screen.id, annotation_mapvalue.index,
@@ -132,8 +132,8 @@ select well.id, well.owner_id, well.group_id,
 annotation_mapvalue.name as mapvalue_name,
 annotation_mapvalue.value as mapvalue_value,
 annotation_mapvalue.index as mapvalue_index from well
-inner join wellannotationlink on well.id =wellannotationlink.parent
-inner join annotation_mapvalue on
+left join wellannotationlink on well.id =wellannotationlink.parent
+left join annotation_mapvalue on
 annotation_mapvalue.annotation_id=wellannotationlink.child
 $whereclause
 GROUP BY well.id,  annotation_mapvalue.index,

--- a/omero_search_engine/cache_functions/elasticsearch/transform_data.py
+++ b/omero_search_engine/cache_functions/elasticsearch/transform_data.py
@@ -656,10 +656,12 @@ def save_key_value_buckets(
         resource_keys = get_keys(resource_table)
         name_results = None
         if resource_table in ["project", "screen"]:
-            sql = "select name,description  from {resource}".format(resource=resource_table)
+            sql = "select name,description  from {resource}".format(
+                resource=resource_table
+            )
             conn = search_omero_app.config["database_connector"]
             name_result = conn.execute_query(sql)
-            #name_results = [res["name"] for res in name_results]
+            # name_results = [res["name"] for res in name_results]
             name_results = {res["name"]: res["description"] for res in name_result}
 
         push_keys_cache_index(resource_keys, resource_table, es_index_2, name_results)

--- a/omero_search_engine/cache_functions/elasticsearch/transform_data.py
+++ b/omero_search_engine/cache_functions/elasticsearch/transform_data.py
@@ -662,7 +662,7 @@ def save_key_value_buckets(
             conn = search_omero_app.config["database_connector"]
             name_result = conn.execute_query(sql)
             # name_results = [res["name"] for res in name_results]
-            name_results = {res["id"]: {"description":res["description"], "name":res["name"]} for res in name_result}
+            name_results = [{"id":res["id"],"description":res["description"], "name":res["name"]} for res in name_result]
 
         push_keys_cache_index(resource_keys, resource_table, es_index_2, name_results)
         if only_values:

--- a/omero_search_engine/cache_functions/elasticsearch/transform_data.py
+++ b/omero_search_engine/cache_functions/elasticsearch/transform_data.py
@@ -34,6 +34,11 @@ from omero_search_engine.cache_functions.elasticsearch.elasticsearch_templates i
     key_value_buckets_info_template,
     key_values_resource_cache_template,
 )
+from omero_search_engine.validation.psql_templates import (
+    query_images_in_project_id,
+    query_images_screen_id,
+)
+
 from app_data.data_attrs import annotation_resource_link
 from datetime import datetime
 import multiprocessing
@@ -662,11 +667,22 @@ def save_key_value_buckets(
             conn = search_omero_app.config["database_connector"]
             name_result = conn.execute_query(sql)
             # name_results = [res["name"] for res in name_results]
+            # Determine the number of images for each container
+            for res in name_result:
+                id = res.get("id")
+                if resource_table == "project":
+                    sql_n = query_images_in_project_id.substitute(project_id=id)
+                elif resource_table == "screen":
+                    sql_n = query_images_screen_id.substitute(screen_id=id)
+                no_images_co = conn.execute_query(sql_n)
+                res["no_images"] = len(no_images_co)
+
             name_results = [
                 {
                     "id": res["id"],
                     "description": res["description"],
                     "name": res["name"],
+                    "no_images": res["no_images"],
                 }
                 for res in name_result
             ]

--- a/omero_search_engine/cache_functions/elasticsearch/transform_data.py
+++ b/omero_search_engine/cache_functions/elasticsearch/transform_data.py
@@ -656,13 +656,13 @@ def save_key_value_buckets(
         resource_keys = get_keys(resource_table)
         name_results = None
         if resource_table in ["project", "screen"]:
-            sql = "select name,description  from {resource}".format(
+            sql = "select id, name,description  from {resource}".format(
                 resource=resource_table
             )
             conn = search_omero_app.config["database_connector"]
             name_result = conn.execute_query(sql)
             # name_results = [res["name"] for res in name_results]
-            name_results = {res["name"]: res["description"] for res in name_result}
+            name_results = {res["id"]: {"description":res["description"], "name":res["name"]} for res in name_result}
 
         push_keys_cache_index(resource_keys, resource_table, es_index_2, name_results)
         if only_values:

--- a/omero_search_engine/cache_functions/elasticsearch/transform_data.py
+++ b/omero_search_engine/cache_functions/elasticsearch/transform_data.py
@@ -662,7 +662,14 @@ def save_key_value_buckets(
             conn = search_omero_app.config["database_connector"]
             name_result = conn.execute_query(sql)
             # name_results = [res["name"] for res in name_results]
-            name_results = [{"id":res["id"],"description":res["description"], "name":res["name"]} for res in name_result]
+            name_results = [
+                {
+                    "id": res["id"],
+                    "description": res["description"],
+                    "name": res["name"],
+                }
+                for res in name_result
+            ]
 
         push_keys_cache_index(resource_keys, resource_table, es_index_2, name_results)
         if only_values:

--- a/omero_search_engine/cache_functions/elasticsearch/transform_data.py
+++ b/omero_search_engine/cache_functions/elasticsearch/transform_data.py
@@ -656,10 +656,11 @@ def save_key_value_buckets(
         resource_keys = get_keys(resource_table)
         name_results = None
         if resource_table in ["project", "screen"]:
-            sql = "select name from {resource}".format(resource=resource_table)
+            sql = "select name,description  from {resource}".format(resource=resource_table)
             conn = search_omero_app.config["database_connector"]
-            name_results = conn.execute_query(sql)
-            name_results = [res["name"] for res in name_results]
+            name_result = conn.execute_query(sql)
+            #name_results = [res["name"] for res in name_results]
+            name_results = {res["name"]: res["description"] for res in name_result}
 
         push_keys_cache_index(resource_keys, resource_table, es_index_2, name_results)
         if only_values:

--- a/omero_search_engine/validation/psql_templates.py
+++ b/omero_search_engine/validation/psql_templates.py
@@ -103,7 +103,7 @@ query_images_in_project_id = Template(
     """
 Select DISTINCT image.id  from image
 inner join datasetimagelink on datasetimagelink.child=image.id
-inner join dataset on datasetimagelink.parent=dataset.idcheckout search
+inner join dataset on datasetimagelink.parent=dataset.id
 inner join projectdatasetlink on dataset.id=projectdatasetlink.child
 inner join  project on project.id=projectdatasetlink.parent
 where project.id=$project_id"""

--- a/omero_search_engine/validation/psql_templates.py
+++ b/omero_search_engine/validation/psql_templates.py
@@ -103,10 +103,10 @@ query_images_in_project_id = Template(
     """
 Select DISTINCT image.id  from image
 inner join datasetimagelink on datasetimagelink.child=image.id
-inner join dataset on datasetimagelink.parent=dataset.id
+inner join dataset on datasetimagelink.parent=dataset.idcheckout search
 inner join projectdatasetlink on dataset.id=projectdatasetlink.child
 inner join  project on project.id=projectdatasetlink.parent
-where project.id=$project_id)"""
+where project.id=$project_id"""
 )
 
 # get images in a project using project name

--- a/omero_search_engine/validation/results_validator.py
+++ b/omero_search_engine/validation/results_validator.py
@@ -323,8 +323,6 @@ class Validator(object):
             None,
             return_containers=True,
         )
-        print(search_engine_results["results"])
-        print("======================")
         if search_engine_results["results"].get("results"):
             for item in search_engine_results["results"].get("results"):
                 if item["type"] == "screen":


### PR DESCRIPTION
It is possible to get all the screen and projects names using the following endpoint

http://idr-testing.openmicroscopy.org/searchengine//api/v1/resources/all/names/

It is possible to replace `all `with a `project `to get the project names only or by `screen `to get the screen names only.

This PR adds a search function to the screen and project name, i.e. it is possible to search for the `project ` and `screen `using a part of the name.  The user sets a `value `to the query, then it will search the names and returns the matching ones

http://idr-testing.openmicroscopy.org/searchengine//api/v1/resources/all/names/?value=idr0012

This addresses issue #54.

It has been deployed to the `idr-testing`.

@will-moore could you please check that and let me what do you think?


