### PR TITLE
Support 'in' and 'not in' operators

### DIFF
--- a/app_data/test_index_data.json
+++ b/app_data/test_index_data.json
@@ -96,5 +96,27 @@
             "validation screen"
          ]
       ]
-   }
+   },
+    "query_in": {
+       "image": [
+         [
+          "Gene Symbol",
+          [
+             "Duoxa2",
+             "Bach2",
+             "Cxcr2",
+             "Mysm1"
+          ]
+          ],
+          [
+          "Organism",
+          [
+             "homo sapiens",
+             "mus musculus",
+             "mus musculus x mus spretus",
+             "human adenovirus 2"
+          ]
+       ]
+          ]
+    }
 }

--- a/examples/search.py
+++ b/examples/search.py
@@ -88,5 +88,9 @@ while len(received_results) < total_results:
         % (len(received_results), total_results, page, total_pages, bookmark)
     )
 
-# 2000 /11686633, page: 1/11687, bookmark: 109600
-# 2000 /12225067, page: 1/12226, bookmark:  109600
+# another example using in operators and send items inside value as a string,
+# The List items are separated by ','
+logging.info("Using in operator")
+url = "%s%s?key=Gene Symbol&value=Pdgfc,Rnase10&operator=in" % (base_url, image_search)
+bookmark, total_results, total_pages = call_omero_return_results(url, method="get")
+logging.info("%s,%s" % (total_results, total_pages))

--- a/examples/using_in_oprators.py
+++ b/examples/using_in_oprators.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2022 University of Dundee & Open Microscopy Environment.
+# All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+from utils import query_the_search_ending, logging
+
+# It is similar to use the 'in' operator in a sql statement,
+# rather than having multiple 'or' conditions,
+# it will only use a single condition.
+
+# The following example will search for the images which have any of the 'Gene Symbol'
+# values in this list ["Duoxa2", "Bach2", "Cxcr2", "Mysm1"]
+
+# and filters
+
+logging.info("Example of using in operator")
+
+
+values_in = ["Duoxa2", "Bach2", "Cxcr2", "Mysm1"]
+logging.info(
+    "Searching for 'Gene Symbol' which its values in [%s]" % (",".join(values_in))
+)
+and_filters = [{"name": "Gene Symbol", "value": values_in, "operator": "in"}]
+
+main_attributes = []
+query = {"and_filters": and_filters}
+#
+recieved_results_data = query_the_search_ending(query, main_attributes)

--- a/examples/using_not_in_operator.py
+++ b/examples/using_not_in_operator.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2022 University of Dundee & Open Microscopy Environment.
+# All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+from utils import query_the_search_ending, logging
+
+# It is similar to use the 'not in' operator in a sql statement,
+# rather than having multiple 'or' conditions with not_equals operators,
+# it will only use a single condition.
+
+# The following example will search for the images which have mpt any of the 'Organism'
+# values in this list
+# ["homo sapiens","mus musculus","mus musculus x mus spretus","human adenovirus 2"]
+
+# and filters
+
+logging.info("Example of using not_in operator")
+
+
+values_not_in = [
+    "homo sapiens",
+    "mus musculus",
+    "mus musculus x mus spretus",
+    "human adenovirus 2",
+]
+logging.info(
+    "Searching for 'Organism' which its values in [%s]" % (",".join(values_not_in))
+)
+and_filters = [{"name": "Organism", "value": values_not_in, "operator": "not_in"}]
+
+main_attributes = []
+query = {"and_filters": and_filters}
+#
+recieved_results_data = query_the_search_ending(query, main_attributes)

--- a/omero_search_engine/api/v1/resources/schemas/filter_schema.json
+++ b/omero_search_engine/api/v1/resources/schemas/filter_schema.json
@@ -13,12 +13,12 @@
     },
      "value": {
       "name":"value",
-      "type": "string"
+      "type": ["array", "string"]
     },
      "operator": {
       "name": "operator",
       "type": "string",
-      "enum": ["equals", "not_equals", "contains","not_contains"]
+      "enum": ["equals", "not_equals", "contains","not_contains","in","not_in"]
     }
      ,"resource": {
       "name": "resource",

--- a/omero_search_engine/api/v1/resources/swagger_docs/search.yml
+++ b/omero_search_engine/api/v1/resources/swagger_docs/search.yml
@@ -28,7 +28,7 @@ parameters:
     description: operator, default equals
     in: query
     type: string
-    enum: ['equals', 'not_equals', 'contains', 'not_contains']
+    enum: ['equals', 'not_equals', 'contains', 'not_contains','in', 'not_in']
   - name: case_sensitive
     description: case sensitive query, default False
     in: query

--- a/omero_search_engine/api/v1/resources/utils.py
+++ b/omero_search_engine/api/v1/resources/utils.py
@@ -113,10 +113,31 @@ case_insensitive_must_value_condition_template = Template(
     """
 {"match": {"key_values.value.keyvaluenormalize":"$value"}}"""
 )
+
+# in operator
+case_insensitive_must_in_value_condition_template = Template(
+    """
+{"terms": {"key_values.value.keyvaluenormalize":$value}}"""
+)
+
 case_sensitive_must_value_condition_template = Template(
     """
 {"match": {"key_values.value.keyvalue":"$value"}}"""
 )
+
+nested_query_template_must_must_not = Template(
+    """
+{"nested": {"path": "key_values",
+"query":{"bool": {"must":[$must_part], "must_not":[$must_not_part]}}}}"""
+)
+
+# in opeartor
+case_sensitive_must_in_value_condition_template = Template(
+    """
+{"terms": {"key_values.value.keyvalue":$value}}"""
+)
+
+
 nested_keyvalue_pair_query_template = Template(
     """
 {"nested": {"path": "key_values",
@@ -291,8 +312,20 @@ def elasticsearch_query_builder(
             search_omero_app.logger.info("FILTER %s" % filter)
             try:
                 key = filter["name"].strip()
-                value = filter["value"].strip()
                 operator = filter["operator"].strip()
+                if operator == "in" or operator == "not_in":
+                    if isinstance(filter["value"], list):
+                        value_ = filter["value"]
+                    else:
+                        # in case of providing it with single query, the values should
+                        # be provided as a string separated the array items by ','
+                        value_ = filter["value"].split(",")
+                    value = [val.strip() for val in value_]
+                    value = json.dumps(value)
+
+                else:
+                    value = filter["value"].strip()
+
             except Exception as e:
                 search_omero_app.logger.info(str(e))
                 return build_error_message(
@@ -333,6 +366,61 @@ def elasticsearch_query_builder(
                         nested=",".join(_nested_must_part)
                     )
                 )
+
+            if operator == "in":
+                if case_sensitive:
+                    _nested_must_part.append(
+                        case_sensitive_must_in_value_condition_template.substitute(  # noqa
+                            value=value
+                        )
+                    )
+                    _nested_must_part.append(
+                        case_sensitive_must_name_condition_template.substitute(name=key)
+                    )  # noqa
+
+                else:
+                    _nested_must_part.append(
+                        case_insensitive_must_in_value_condition_template.substitute(  # noqa
+                            value=value
+                        )
+                    )
+                    _nested_must_part.append(
+                        case_insensitive_must_name_condition_template.substitute(  # noqa
+                            name=key
+                        )
+                    )
+
+                nested_must_part.append(
+                    nested_keyvalue_pair_query_template.substitute(
+                        nested=",".join(_nested_must_part)
+                    )
+                )
+
+            if operator == "not_in":
+                if case_sensitive:
+                    nested_must_part.append(
+                        nested_query_template_must_must_not.substitute(
+                            must_not_part=case_sensitive_must_in_value_condition_template.substitute(  # noqa
+                                value=value
+                            ),
+                            must_part=case_sensitive_must_name_condition_template.substitute(  # noqa
+                                name=key
+                            ),
+                        )
+                    )
+
+                else:
+                    nested_must_part.append(
+                        nested_query_template_must_must_not.substitute(
+                            must_not_part=case_insensitive_must_in_value_condition_template.substitute(  # noqa
+                                value=value
+                            ),
+                            must_part=case_insensitive_must_name_condition_template.substitute(  # noqa
+                                name=key
+                            ),
+                        )
+                    )
+
             if operator == "contains":
                 value = "*{value}*".format(value=adjust_value(value))
                 # _nested_must_part.append(must_name_condition_template.substitute(name=key)) # noqa
@@ -371,64 +459,50 @@ def elasticsearch_query_builder(
                     value = "*{value}*".format(value=adjust_value(value))
                     if case_sensitive:
                         nested_must_part.append(
-                            nested_keyvalue_pair_query_template.substitute(
-                                nested=case_sensitive_must_name_condition_template.substitute(  # noqa
-                                    name=key
-                                )
-                            )
-                        )
-                        nested_must_not_part.append(
-                            nested_keyvalue_pair_query_template.substitute(
-                                nested=case_sensitive_wildcard_value_condition_template.substitute(  # noqa
+                            nested_query_template_must_must_not.substitute(
+                                must_not_part=case_sensitive_wildcard_value_condition_template.substitute(  # noqa
                                     wild_card_value=value
-                                )
+                                ),
+                                must_part=case_sensitive_must_name_condition_template.substitute(  # noqa
+                                    name=key
+                                ),
                             )
                         )
+
                     else:
                         nested_must_part.append(
-                            nested_keyvalue_pair_query_template.substitute(
-                                nested=case_insensitive_must_name_condition_template.substitute(  # noqa
-                                    name=key
-                                )
-                            )
-                        )
-                        nested_must_not_part.append(
-                            nested_keyvalue_pair_query_template.substitute(
-                                nested=case_insensitive_wildcard_value_condition_template.substitute(  # noqa
+                            nested_query_template_must_must_not.substitute(
+                                must_not_part=case_insensitive_wildcard_value_condition_template.substitute(  # noqa
                                     wild_card_value=value
-                                )
+                                ),
+                                must_part=case_insensitive_must_name_condition_template.substitute(  # noqa
+                                    name=key
+                                ),
                             )
                         )
 
                 else:
                     if case_sensitive:
                         nested_must_part.append(
-                            nested_keyvalue_pair_query_template.substitute(
-                                nested=case_sensitive_must_name_condition_template.substitute(  # noqa
-                                    name=key
-                                )
-                            )
-                        )
-                        nested_must_not_part.append(
-                            nested_keyvalue_pair_query_template.substitute(
-                                nested=case_sensitive_must_value_condition_template.substitute(  # noqa
+                            nested_query_template_must_must_not.substitute(
+                                must_not_part=case_sensitive_must_value_condition_template.substitute(  # noqa
                                     value=value
-                                )
+                                ),
+                                must_part=case_sensitive_must_name_condition_template.substitute(  # noqa
+                                    name=key
+                                ),
                             )
                         )
+
                     else:
                         nested_must_part.append(
-                            nested_keyvalue_pair_query_template.substitute(
-                                nested=case_insensitive_must_name_condition_template.substitute(  # noqa
-                                    name=key
-                                )
-                            )
-                        )
-                        nested_must_not_part.append(
-                            nested_keyvalue_pair_query_template.substitute(
-                                nested=case_insensitive_must_value_condition_template.substitute(  # noqa
+                            nested_query_template_must_must_not.substitute(
+                                must_not_part=case_insensitive_must_value_condition_template.substitute(  # noqa
                                     value=value
-                                )
+                                ),
+                                must_part=case_insensitive_must_name_condition_template.substitute(  # noqa
+                                    name=key
+                                ),
                             )
                         )
 
@@ -618,7 +692,6 @@ def elasticsearch_query_builder(
                     ff = nested_query_template_must_not.substitute(must_not_value=ss)
                     should_part_list_or.append(ff)
     all_terms = ""
-
     for should_part_list_ in all_should_part_list:
         if isinstance(should_part_list_, dict):
             should_part_list = should_part_list_.get("main")

--- a/omero_search_engine/validation/psql_templates.py
+++ b/omero_search_engine/validation/psql_templates.py
@@ -49,7 +49,7 @@ inner join imageannotationlink on image.id =imageannotationlink.parent
 inner join annotation_mapvalue on
 annotation_mapvalue.annotation_id=imageannotationlink.child
 where lower(annotation_mapvalue.name)='$name' and
-lower(annotation_mapvalue.value)=lower('$value')"""
+lower(annotation_mapvalue.value)$operator lower('$value')"""
 )
 
 # Get number of images which satisfy project key-value query
@@ -65,11 +65,11 @@ on project.id =projectannotationlink.parent
 inner join annotation_mapvalue
 on annotation_mapvalue.annotation_id=projectannotationlink.child
 where lower(annotation_mapvalue.name)=lower('$name')
-and lower(annotation_mapvalue.value)=lower('$value')"""
+and lower(annotation_mapvalue.value)$operator lower('$value')"""
 )
 
 # Get the  number of images using "in"
-query_image_or = Template(
+query_image_in = Template(
     """
 Select DISTINCT image.id from image
 inner join imageannotationlink
@@ -77,7 +77,7 @@ on image.id =imageannotationlink.parent
 inner join annotation_mapvalue
 on annotation_mapvalue.annotation_id=imageannotationlink.child
 where lower(annotation_mapvalue.name) in ($names)
-and lower(annotation_mapvalue.value) in ($values)"""
+and lower(annotation_mapvalue.value) $operator ($values)"""
 )
 
 # Get the images which satisfy screen key-value query
@@ -93,8 +93,8 @@ inner join screenannotationlink
 on screen.id =screenannotationlink.parent
 inner join annotation_mapvalue
 on annotation_mapvalue.annotation_id=screenannotationlink.child
-where lower(annotation_mapvalue.name)='$name'
-and lower(annotation_mapvalue.value)=lower('$value')"""
+where lower(annotation_mapvalue.name)= lower('$name')
+and lower(annotation_mapvalue.value)$operator lower('$value')"""
 )
 
 
@@ -117,7 +117,7 @@ inner join datasetimagelink on datasetimagelink.child=image.id
 inner join dataset on datasetimagelink.parent=dataset.id
 inner join projectdatasetlink on dataset.id=projectdatasetlink.child
 inner join project on project.id=projectdatasetlink.parent
-where lower(project.name)=lower('$name')"""
+where lower (project.name) $operator lower ('$name')"""
 )
 
 # get images in a screen using id
@@ -141,7 +141,7 @@ inner join well on wellsample.well= well.id
 inner join plate on well.plate=plate.id
 inner join screenplatelink on plate.id=screenplatelink.child
 inner join screen on screen.id=screenplatelink.parent
-where lower(screen.name)=lower('$name')"""
+where lower(screen.name)$operator lower('$name')"""
 )
 
 # get resource id using its name

--- a/omero_search_engine/validation/results_validator.py
+++ b/omero_search_engine/validation/results_validator.py
@@ -506,8 +506,8 @@ class Validator(object):
             searchengine_no = self.searchengine_results
         return (
             "not equal, database no of the results from database server is: %s and"
-             "the number of results from searchengine is %s?,"
-             "\ndatabase server query time= %s, searchengine query time= %s"
+            "the number of results from searchengine is %s?,"
+            "\ndatabase server query time= %s, searchengine query time= %s"
             % (len(self.postgres_results), searchengine_no, sql_time, searchengine_time)
         )
 
@@ -548,7 +548,7 @@ def validate_queries(json_file, deep_check):
             elabsed_time = str(datetime.now() - start_time)
             messages.append(
                 "Results form (equals) PostgreSQL and search engine"
-                 "for name: %s , value: %s are: %s"
+                "for name: %s , value: %s are: %s"
                 % (validator.name, validator.value, res)
             )
             search_omero_app.logger.info("Total time=%s" % elabsed_time)
@@ -566,7 +566,7 @@ def validate_queries(json_file, deep_check):
                 elabsed_time = str(datetime.now() - start_time)
                 messages.append(
                     "Results (not_equals) form PostgreSQL and search engine"
-                     "for name: %s , value: %s are: %s"
+                    "for name: %s , value: %s are: %s"
                     % (not_equls_validator.name, not_equls_validator.value, res)
                 )
                 search_omero_app.logger.info("Total time=%s" % elabsed_time)


### PR DESCRIPTION
This PR replaces #31 as it contains the required changes to support the `in` and `not_in` operators. This will make the review easier.

There are two examples are added to explain using both operators  i.e. `using_in_oprators.py` and `using_not_in_operator.py`

Example of using `in` operator with the single query endpoint:

https://idr-testing.openmicroscopy.org/searchengine//api/v1/resources/image/search/?key=Gene%20Symbol&value=Duoxa2,Bach2,Cxcr2,Mysm1&operator=in

Example of using `not_in `operator with the single query endpoint:

http://idr-testing.openmicroscopy.org/searchengine//api/v1/resources/image/search/?key=Organism&value=homo%20sapiens,mus%20musculus,mus%20musculus%20x%20mus%20spretus,human%20adenovirus%202&operator=not_in

It is deployed on the `Idr-testing`.

