### PR TITLE
Search containers

### DIFF
--- a/examples/return_studies_using_container.py
+++ b/examples/return_studies_using_container.py
@@ -55,7 +55,6 @@ data = {
     "query_details": {
         "and_filters": [
             {
-
                 "name": "Imaging Method",
                 "value": "light sheet fluorescence microscopy, spim",
                 "operator": "equals",
@@ -71,10 +70,9 @@ data_1 = {
     "resource": "image",
     "query_details": {
         "and_filters": [
-
             {
                 "name": "Publication Title",
-                "value":"Parallel compound screen for infection modulators identifies re-purposing candidates against common viral infections",
+                "value": "Parallel compound screen for infection modulators identifies re-purposing candidates against common viral infections",
                 "operator": "equals",
                 "resource": "container",
             },
@@ -91,7 +89,10 @@ if returned_results.get("results"):
         logging.info("No results is found")
     for item in returned_results.get("results").get("results"):
         logging.info("Study: %s" % item.get("name"))
-    logging.info("Total number of containers: %s"% len(returned_results.get("results").get("results")))
+    logging.info(
+        "Total number of containers: %s"
+        % len(returned_results.get("results").get("results"))
+    )
 
 resp = requests.post(submit_query_url, data=json.dumps(data_1))
 returned_results = json.loads(resp.text)
@@ -100,4 +101,7 @@ if returned_results.get("results"):
         logging.info("No results is found")
     for item in returned_results.get("results").get("results"):
         logging.info("Study: %s" % item.get("name"))
-    logging.info("Total number of containers: %s"% len(returned_results.get("results").get("results")))
+    logging.info(
+        "Total number of containers: %s"
+        % len(returned_results.get("results").get("results"))
+    )

--- a/examples/return_studies_using_container.py
+++ b/examples/return_studies_using_container.py
@@ -32,11 +32,11 @@ The following query will answer this question:
 Get a list of studies which satisfy the following conditions:
 "Organism"="mus musculus"
  and
-"Imaging Method"="light sheet fluorescence microscopy, spim"
+"Imaging Method"="spim"
 """
 logging.info(
     "Get a study list for:  (Organism= mus musculus) and \
-    (Imaging Method=light sheet fluorescence microscopy, spim)"
+    (Imaging Method=spim)"
 )
 
 """
@@ -56,7 +56,7 @@ data = {
         "and_filters": [
             {
                 "name": "Imaging Method",
-                "value": "light sheet fluorescence microscopy, spim",
+                "value": "spim",
                 "operator": "equals",
                 "resource": "container",
             },

--- a/examples/return_studies_using_container.py
+++ b/examples/return_studies_using_container.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2022 University of Dundee & Open Microscopy Environment.
+# All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import logging
+import json
+import requests
+import sys
+from utils import base_url
+
+# url to send the query
+submit_query_url = f"{base_url}resources/submitquery/containers/"
+
+logging.basicConfig(stream=sys.stdout, level=logging.INFO)
+"""
+The following query will answer this question:
+Get a list of studies which satisfy the following conditions:
+"Organism"="mus musculus"
+ and
+"Imaging Method"="light sheet fluorescence microscopy, spim"
+"""
+logging.info(
+    "Get a study list for:  (Organism= mus musculus) and \
+    (Imaging Method=light sheet fluorescence microscopy, spim)"
+)
+
+"""
+url="%s%s?key=Organism&value=Homo sapiens&return_containers=true"%(base_url,image_search)  # noqa
+resp = requests.get(url)
+returned_results = json.loads(resp.text)
+if returned_results.get("results"):
+    if len(returned_results.get("results").get("results"))==0:
+        logging.info ("No results is found")
+    for item in returned_results.get("results").get("results"):
+        logging.info ("Study: %s"%item.get("Name (IDR number)"))
+"""
+
+data = {
+    "resource": "image",
+    "query_details": {
+        "and_filters": [
+            {
+
+                "name": "Imaging Method",
+                "value": "light sheet fluorescence microscopy, spim",
+                "operator": "equals",
+                "resource": "container",
+            },
+        ],
+        "or_filters": [],
+        "case_sensitive": False,
+    },
+}
+
+data_1 = {
+    "resource": "image",
+    "query_details": {
+        "and_filters": [
+
+            {
+                "name": "Publication Title",
+                "value":"Parallel compound screen for infection modulators identifies re-purposing candidates against common viral infections",
+                "operator": "equals",
+                "resource": "container",
+            },
+        ],
+        "or_filters": [],
+        "case_sensitive": False,
+    },
+}
+
+resp = requests.post(submit_query_url, data=json.dumps(data))
+returned_results = json.loads(resp.text)
+if returned_results.get("results"):
+    if len(returned_results.get("results").get("results")) == 0:
+        logging.info("No results is found")
+    for item in returned_results.get("results").get("results"):
+        logging.info("Study: %s" % item.get("name"))
+    logging.info("Total number of containers: %s"% len(returned_results.get("results").get("results")))
+
+resp = requests.post(submit_query_url, data=json.dumps(data_1))
+returned_results = json.loads(resp.text)
+if returned_results.get("results"):
+    if len(returned_results.get("results").get("results")) == 0:
+        logging.info("No results is found")
+    for item in returned_results.get("results").get("results"):
+        logging.info("Study: %s" % item.get("name"))
+    logging.info("Total number of containers: %s"% len(returned_results.get("results").get("results")))

--- a/examples/return_studies_using_container.py
+++ b/examples/return_studies_using_container.py
@@ -72,7 +72,8 @@ data_1 = {
         "and_filters": [
             {
                 "name": "Publication Title",
-                "value": "Parallel compound screen for infection modulators identifies re-purposing candidates against common viral infections",
+                "value": "Parallel compound screen for infection modulators identifies "
+                "re-purposing candidates against common viral infections",
                 "operator": "equals",
                 "resource": "container",
             },

--- a/manage.py
+++ b/manage.py
@@ -291,12 +291,14 @@ def test_indexing_search_query(
         validate_queries,
         test_no_images,
         get_omero_stats,
+        get_no_images_sql_containers,
     )
 
     validate_queries(json_file, deep_check)
     if check_studies:
         test_no_images()
     get_omero_stats()
+    get_no_images_sql_containers()
 
 
 if __name__ == "__main__":

--- a/omero_search_engine/api/v1/resources/query_handler.py
+++ b/omero_search_engine/api/v1/resources/query_handler.py
@@ -81,7 +81,9 @@ class QueryItem(object):
         if mapping_names.get(self.resource):
             if mapping_names[self.resource].get(self.name):
                 ac_value, act_res = check_get_names(self.value)
-                if len(ac_value) == 1:
+                if len(ac_value) == 0:
+                    self.value = -1
+                elif len(ac_value) == 1:
                     self.value = ac_value[0]
                 elif len(ac_value) > 1:
                     self.value = ac_value

--- a/omero_search_engine/api/v1/resources/query_handler.py
+++ b/omero_search_engine/api/v1/resources/query_handler.py
@@ -200,10 +200,10 @@ class QueryRunner(
                         main_or_attribute[resource] = (
                             main_or_attribute[resource] + new_cond
                         )
-                elif len(main_or_attribute.keys()) == 0 and len(
-                            checked_list
-                        ) == len(or_it.resources_query):
-                            return {"Error": "Your query returns no results"}
+                elif len(main_or_attribute.keys()) == 0 and len(checked_list) == len(
+                    or_it.resources_query
+                ):
+                    return {"Error": "Your query returns no results"}
         # check or_filters
         for or_it in self.or_query_group:
             checked_list = []

--- a/omero_search_engine/api/v1/resources/query_handler.py
+++ b/omero_search_engine/api/v1/resources/query_handler.py
@@ -81,9 +81,7 @@ class QueryItem(object):
         if mapping_names.get(self.resource):
             if mapping_names[self.resource].get(self.name):
                 ac_value, act_res = check_get_names(self.value)
-                if len(ac_value) == 0:
-                    self.value = -1
-                elif len(ac_value) == 1:
+                if len(ac_value) == 1:
                     self.value = ac_value[0]
                 elif len(ac_value) > 1:
                     self.value = ac_value

--- a/omero_search_engine/api/v1/resources/query_handler.py
+++ b/omero_search_engine/api/v1/resources/query_handler.py
@@ -202,7 +202,9 @@ class QueryRunner(
                     return {"Error": "Your query returns no results"}
         # check or_filters
         for or_it in self.or_query_group:
+            checked_list = []
             for resource, or_query in or_it.resources_query.items():
+                checked_list.append(resource)
                 if resource == "image":
                     image_or_queries.append(or_query)
                 else:
@@ -225,7 +227,11 @@ class QueryRunner(
                         # main_or_attribute.append(new_cond)
                         # self.additional_image_conds.append(new_cond)
                     else:
-                        return {"Error": "Your query returns no results"}
+                        # check if all the conditions have been checked
+                        if len(main_or_attribute.keys()) == 0 and len(
+                            checked_list
+                        ) == len(or_it.resources_query):
+                            return {"Error": "Your query returns no results"}
         # check and main attributes
         for and_it in self.and_query_group:
             for resource, main in and_it.main_attribute.items():

--- a/omero_search_engine/api/v1/resources/query_handler.py
+++ b/omero_search_engine/api/v1/resources/query_handler.py
@@ -186,7 +186,9 @@ class QueryRunner(
         # then run and add the results (in term of clauses)
         # to the main image query
         for or_it in self.or_query_group:
+            checked_list = []
             for resource, main in or_it.main_attribute.items():
+                checked_list.append(resource)
                 query = {}
                 query["main_attribute"] = main
                 res = self.run_query(query, resource)
@@ -198,8 +200,10 @@ class QueryRunner(
                         main_or_attribute[resource] = (
                             main_or_attribute[resource] + new_cond
                         )
-                else:
-                    return {"Error": "Your query returns no results"}
+                elif len(main_or_attribute.keys()) == 0 and len(
+                            checked_list
+                        ) == len(or_it.resources_query):
+                            return {"Error": "Your query returns no results"}
         # check or_filters
         for or_it in self.or_query_group:
             checked_list = []

--- a/omero_search_engine/api/v1/resources/query_handler.py
+++ b/omero_search_engine/api/v1/resources/query_handler.py
@@ -187,6 +187,7 @@ class QueryRunner(
         # to the main image query
         for or_it in self.or_query_group:
             checked_list = []
+            main_or_attribute_ = {}
             for resource, main in or_it.main_attribute.items():
                 checked_list.append(resource)
                 query = {}
@@ -194,19 +195,27 @@ class QueryRunner(
                 res = self.run_query(query, resource)
                 new_cond = get_ids(res, resource)
                 if new_cond:
-                    if not main_or_attribute.get(resource):
-                        main_or_attribute[resource] = new_cond
+                    if not main_or_attribute_.get(resource):
+                        main_or_attribute_[resource] = new_cond
                     else:
-                        main_or_attribute[resource] = (
-                            main_or_attribute[resource] + new_cond
+                        main_or_attribute_[resource] = (
+                            main_or_attribute_[resource] + new_cond
                         )
-                elif len(main_or_attribute.keys()) == 0 and len(checked_list) == len(
+                elif len(main_or_attribute_.keys()) == 0 and len(checked_list) == len(
                     or_it.resources_query
                 ):
                     return {"Error": "Your query returns no results"}
+            for res, items_ in main_or_attribute_.items():
+                if res not in main_or_attribute:
+                    main_or_attribute[res] = items_
+                else:
+                    main_or_attribute[res] = combine_conds(
+                        main_or_attribute[res], items_, res
+                    )
         # check or_filters
         for or_it in self.or_query_group:
             checked_list = []
+            main_or_attribute_ = {}
             for resource, or_query in or_it.resources_query.items():
                 checked_list.append(resource)
                 if resource == "image":
@@ -221,21 +230,28 @@ class QueryRunner(
                     res = self.run_query(query, resource)
                     new_cond = get_ids(res, resource)
                     if new_cond:
-                        if not main_or_attribute.get(resource):
-                            main_or_attribute[resource] = new_cond
+                        if not main_or_attribute_.get(resource):
+                            main_or_attribute_[resource] = new_cond
                         else:
-                            main_or_attribute[resource] = (
-                                main_or_attribute[resource] + new_cond
+                            main_or_attribute_[resource] = (
+                                main_or_attribute_[resource] + new_cond
                             )
 
                         # main_or_attribute.append(new_cond)
                         # self.additional_image_conds.append(new_cond)
                     else:
                         # check if all the conditions have been checked
-                        if len(main_or_attribute.keys()) == 0 and len(
+                        if len(main_or_attribute_.keys()) == 0 and len(
                             checked_list
                         ) == len(or_it.resources_query):
                             return {"Error": "Your query returns no results"}
+            for res, items_ in main_or_attribute_.items():
+                if res not in main_or_attribute:
+                    main_or_attribute[res] = items_
+                else:
+                    main_or_attribute[res] = combine_conds(
+                        main_or_attribute[res], items_, res
+                    )
         # check and main attributes
         for and_it in self.and_query_group:
             for resource, main in and_it.main_attribute.items():

--- a/omero_search_engine/api/v1/resources/swagger_docs/submitquery_returncontainers.yml
+++ b/omero_search_engine/api/v1/resources/swagger_docs/submitquery_returncontainers.yml
@@ -36,7 +36,7 @@ Another example:
         },
         {
           "name": "Imaging Method",
-          "value": "light sheet fluorescence microscopy, spim",
+          "value": "spim",
           "operator": "equals",
           "resource": "project"
         }

--- a/omero_search_engine/api/v1/resources/urls.py
+++ b/omero_search_engine/api/v1/resources/urls.py
@@ -23,6 +23,7 @@ import json
 from omero_search_engine.api.v1.resources.utils import (
     search_resource_annotation,
     build_error_message,
+    adjust_query_for_container,
 )
 from omero_search_engine.api.v1.resources.resource_analyser import (
     search_value_for_resource,
@@ -311,6 +312,7 @@ def submit_query_return_containers():
         query = None
     if not query:
         return jsonify(build_error_message("No query is provided"))
+    adjust_query_for_container(query)
     return_columns = request.args.get("return_columns")
     if return_columns:
         try:
@@ -337,6 +339,7 @@ def submit_query():
         query = None
     if not query:
         return jsonify(build_error_message("No query is provided"))
+    adjust_query_for_container(query)
     return_columns = request.args.get("return_columns")
     if return_columns:
         try:

--- a/omero_search_engine/api/v1/resources/utils.py
+++ b/omero_search_engine/api/v1/resources/utils.py
@@ -1074,6 +1074,9 @@ def adjust_query_for_container(query):
                     if filter.get("resource") == "container":
                         new_or_filters.append(get_filter_list(filter))
                         to_delete_or_filter.append(filter)
+        else:
+            or_filters = []
+            query_details["or_filters"] = or_filters
         for filter in to_delete_or_filter:
             if filter in or_filters:
                 or_filters.remove(filter)

--- a/omero_search_engine/api/v1/resources/utils.py
+++ b/omero_search_engine/api/v1/resources/utils.py
@@ -1048,7 +1048,8 @@ def get_filter_list(filter):
     new_or_filter.append(f2)
     return new_or_filter
 
-\def adjust_query_for_container(query):
+
+def adjust_query_for_container(query):
     query_details = query.get("query_details")
     new_or_filters = []
     to_delete_and_filter = []

--- a/omero_search_engine/api/v1/resources/utils.py
+++ b/omero_search_engine/api/v1/resources/utils.py
@@ -1063,9 +1063,6 @@ def adjust_query_for_container(query):
                     to_delete_and_filter.append(filter)
 
         or_filters = query_details.get("or_filters")
-        if not or_filters:
-            or_filters = []
-            query_details["or_filters"] = or_filters
         if or_filters:
             for filter in or_filters:
                 if isinstance(filter, list):

--- a/omero_search_engine/api/v1/resources/utils.py
+++ b/omero_search_engine/api/v1/resources/utils.py
@@ -1063,6 +1063,9 @@ def adjust_query_for_container(query):
                     to_delete_and_filter.append(filter)
 
         or_filters = query_details.get("or_filters")
+        if not or_filters:
+            or_filters = []
+            query_details["or_filters"] = or_filters
         if or_filters:
             for filter in or_filters:
                 if isinstance(filter, list):

--- a/omero_search_engine/api/v1/resources/utils.py
+++ b/omero_search_engine/api/v1/resources/utils.py
@@ -1048,8 +1048,7 @@ def get_filter_list(filter):
     new_or_filter.append(f2)
     return new_or_filter
 
-
-def adjust_query_for_container(query):
+\def adjust_query_for_container(query):
     query_details = query.get("query_details")
     new_or_filters = []
     to_delete_and_filter = []
@@ -1065,12 +1064,23 @@ def adjust_query_for_container(query):
         or_filters = query_details.get("or_filters")
         if or_filters:
             for filter in or_filters:
-                if filter.get("resource") == "container":
-                    new_or_filters.append(get_filter_list(filter))
-                    to_delete_or_filter.append(filter)
-
+                if isinstance(filter, list):
+                    for filter_ in filter:
+                        if filter_.get("resource") == "container":
+                            new_or_filters.append(get_filter_list(filter_))
+                            to_delete_or_filter.append(filter_)
+                else:
+                    if filter.get("resource") == "container":
+                        new_or_filters.append(get_filter_list(filter))
+                        to_delete_or_filter.append(filter)
         for filter in to_delete_or_filter:
-            or_filters.remove(filter)
+            if filter in or_filters:
+                or_filters.remove(filter)
+            else:
+                for _filter in or_filters:
+                    if isinstance(_filter, list):
+                        if filter in _filter:
+                            _filter.remove(filter)
 
         for filter in to_delete_and_filter:
             and_filters.remove(filter)

--- a/omero_search_engine/api/v1/resources/utils.py
+++ b/omero_search_engine/api/v1/resources/utils.py
@@ -1034,3 +1034,46 @@ def get_studies_titles(idr_name, resource):
                 del value["name"]
         study_title["key_values"] = item_.get("key_values")
     return study_title
+
+
+def get_filter_list(filter):
+    import copy
+
+    new_or_filter = []
+    f1 = copy.deepcopy(filter)
+    f1["resource"] = "project"
+    new_or_filter.append(f1)
+    f2 = copy.deepcopy(filter)
+    f2["resource"] = "screen"
+    new_or_filter.append(f2)
+    return new_or_filter
+
+
+def adjust_query_for_container(query):
+    query_details = query.get("query_details")
+    new_or_filters = []
+    to_delete_and_filter = []
+    to_delete_or_filter = []
+    if query_details:
+        and_filters = query_details.get("and_filters")
+        if and_filters:
+            for filter in and_filters:
+                if filter.get("resource") == "container":
+                    new_or_filters.append(get_filter_list(filter))
+                    to_delete_and_filter.append(filter)
+
+        or_filters = query_details.get("or_filters")
+        if or_filters:
+            for filter in or_filters:
+                if filter.get("resource") == "container":
+                    new_or_filters.append(get_filter_list(filter))
+                    to_delete_or_filter.append(filter)
+
+        for filter in to_delete_or_filter:
+            or_filters.remove(filter)
+
+        for filter in to_delete_and_filter:
+            and_filters.remove(filter)
+
+        for filter in new_or_filters:
+            or_filters.append(filter)


### PR DESCRIPTION
This PR is implementing issue #65.
It allows the use of a container as a resource; the searchengine will find the results using the screen and project.
For example, the following query will search the `Publication Authors` attribute that its value contains `Ellenberg`  for both screens and projects and return matching results.

```
{
   "query_details":{
      "and_filters":[
         {
            "name":"Publication Authors",
            "value":"Ellenberg",
            "operator":"contains",
            "resource":"container"
         }
      ],
      "or_filters":[
         
      ]
   }
}
```

@will-moore   I have deployed this in `idr-testing`,  could you please check that and let me what you think?