### PR TITLE
Fix issue #79

### DIFF
--- a/omero_search_engine/api/v1/resources/query_handler.py
+++ b/omero_search_engine/api/v1/resources/query_handler.py
@@ -274,6 +274,13 @@ class QueryRunner(
                     main_or_attribute[res] = combine_conds(
                         main_or_attribute[res], items_, res
                     )
+
+        if len(self.or_query_group) > 0 and len(image_or_queries) == 0:
+            no_conds = 0
+            for res, item in main_or_attribute.items():
+                no_conds += len(item)
+            if no_conds == 0:
+                return {"Error": "Your query returns no results"}
         # check and main attributes
         for and_it in self.and_query_group:
             for resource, main in and_it.main_attribute.items():
@@ -499,8 +506,15 @@ def get_ids(results, resource):
             qur_item["resource"] = resource
             qur_item_ = QueryItem(qur_item)
             ids.append(qur_item_)
-        return ids
-    return None
+    else:
+        qur_item = {}
+        qur_item["name"] = "{resource}_id".format(resource=resource)
+        qur_item["value"] = -1
+        qur_item["operator"] = "equals"
+        qur_item["resource"] = resource
+        qur_item_ = QueryItem(qur_item)
+        ids.append(qur_item_)
+    return ids
 
 
 def process_search_results(results, resource, columns_def):


### PR DESCRIPTION
I have fixed this issue and deployed it in `idr-testing`.
It is possible to check the fix by comparing the link from `idr-testing`  and the one from the `idr-next, i.e. 45.88.81.82`. 

- `idr-testing (fixed one)`

http://idr-testing.openmicroscopy.org/search/?key=Organism&value=mus+musculus&operator=equals&resource=container

- `idr-next (still has the issue)`

http://45.88.81.82/search/?key=Organism&value=mus+musculus&operator=equals&resource=container

It is also possible to check the API using this query in both idr-next and idr-testing using submitquery endpoint:

```
{
  "resource": "image",
  "query_details": {
    "and_filters": [
      {
        "name": "Organism",
        "operator": "equals",
        "resource": "container",
        "value": "Mus musculus"
      },
      {
        "name": "name",
        "operator": "equals",
        "resource": "container",
        "value": "idr0064-goglia-erkdynamics/screenA"
      }
    ],
    "case_sensitive": false,
    "or_filters": []
  }
}
```

- This command can be used to test `idr-testing`

`curl -X POST "https://idr-testing.openmicroscopy.org/searchengine//api/v1/resources/submitquery/" -H "accept: application/json" -H "Content-Type: application/json" -d "{ \"resource\": \"image\", \"query_details\": { \"and_filters\": [ { \"name\": \"Organism\", \"operator\": \"equals\", \"resource\": \"container\", \"value\": \"Mus musculus\" }, { \"name\": \"name\", \"operator\": \"equals\", \"resource\": \"container\", \"value\": \"idr0064-goglia-erkdynamics/screenA\" } ], \"case_sensitive\": false, \"or_filters\": [] }}"`

- This command can be used to check `idr-next`

`curl -X POST "http://45.88.81.82/searchengine//api/v1/resources/submitquery/" -H "accept: application/json" -H "Content-Type: application/json" -d "{ \"resource\": \"image\", \"query_details\": { \"and_filters\": [ { \"name\": \"Organism\", \"operator\": \"equals\", \"resource\": \"container\", \"value\": \"Mus musculus\" }, { \"name\": \"name\", \"operator\": \"equals\", \"resource\": \"container\", \"value\": \"idr0064-goglia-erkdynamics/screenA\" } ], \"case_sensitive\": false, \"or_filters\": [] }}"`

