### PR TITLE
Secure the connection with the elsticsearch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,10 +24,10 @@ jobs:
           --health-retries 5
 
       elasticsearch:
-        image: elasticsearch:7.16.2
+        image: elasticsearch:8.8.1
         ports:
           - 9200/tcp
-        options: -e="discovery.type=single-node" --health-cmd="curl http://localhost:9200/_cluster/health" --health-interval=10s --health-timeout=5s --health-retries=10
+        options: -e="discovery.type=single-node"  -e="ELASTIC_PASSWORD=elasticsearch_user_password" --health-cmd="curl http://localhost:9200/_cluster/health" --health-interval=10s --health-timeout=5s --health-retries=10
 
     steps:
       - uses: actions/checkout@v2
@@ -84,5 +84,3 @@ jobs:
           file: deployment/docker/centos/Dockerfile
           push: true
           tags: ${{ join(fromJson(steps.gettags.outputs.tags)) }}
-
-

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
         image: elasticsearch:8.8.1
         ports:
           - 9200/tcp
-        options: -e="discovery.type=single-node"  -e="ELASTIC_PASSWORD=elasticsearch_user_password" --health-cmd="curl http://localhost:9200/_cluster/health" --health-interval=10s --health-timeout=5s --health-retries=10
+        options: -e="discovery.type=single-node" --es_api_basic_auth_username="elastic"  --ELASTIC_PASSWORD="elasticsearch_user_password" --health-cmd="curl -k -u elastic:elasticsearch_user_password  https://localhost:9200/_cluster/health" --health-interval=10s --health-timeout=5s --health-retries=10
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,11 @@ jobs:
         image: elasticsearch:8.8.1
         ports:
           - 9200/tcp
-        options: -e="discovery.type=single-node" --es_api_basic_auth_username="elastic"  --ELASTIC_PASSWORD="elasticsearch_user_password" --health-cmd="curl -k -u elastic:elasticsearch_user_password  https://localhost:9200/_cluster/health" --health-interval=10s --health-timeout=5s --health-retries=10
+        env:
+          es_api_basic_auth_username: "elastic"
+          ELASTIC_PASSWORD: "elasticsearch_user_password"
+
+        options: -e="discovery.type=single-node" --health-cmd="curl -k -u elastic:elasticsearch_user_password  https://localhost:9200/_cluster/health" --health-interval=10s --health-timeout=5s --health-retries=10
 
     steps:
       - uses: actions/checkout@v2

--- a/configurations/app_config.yml
+++ b/configurations/app_config.yml
@@ -12,3 +12,5 @@ PAGE_SIZE : 1000
 CACHE_ROWS : 10000
 MAX_RETUNED_ITEMS : 1700000
 ELASTICSEARCH_BACKUP_FOLDER: "path/to/elasticsearch/backup/folder"
+verify_certs: False
+ELASTIC_PASSWORD: elasticsearch_user_password

--- a/configurations/app_config.yml
+++ b/configurations/app_config.yml
@@ -6,7 +6,7 @@ DATABASE_NAME : "omero"
 CACHE_FOLDER : "path/to/folder/app_data"
 SECRET_KEY : "fsdasdh3424vvcsd467fgh"
 ASYNCHRONOUS_SEARCH : True
-ELASTICSEARCH_URL : "http://localhost:9200"
+ELASTICSEARCH_URL : "https://localhost:9200"
 IDR_TEST_FILE_URL : "https://raw.githubusercontent.com/IDR/idr.openmicroscopy.org/master/_data/studies.tsv"
 PAGE_SIZE : 1000
 CACHE_ROWS : 10000

--- a/configurations/configuration.py
+++ b/configurations/configuration.py
@@ -33,14 +33,16 @@ def load_configuration_variables_from_file(config):
     if hasattr(config, "verify_certs"):
         try:
             verify_certs = json.load(config.verify_certs)
-        except:
+        except Exception as ex:
+            print(str(ex))
             verify_certs = False
     else:
-        verify_certs=False
-    config.verify_certs=verify_certs
+        verify_certs = False
+    config.verify_certs = verify_certs
     if not verify_certs:
         import requests
         from requests.packages.urllib3.exceptions import InsecureRequestWarning
+
         requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 
 

--- a/configurations/configuration.py
+++ b/configurations/configuration.py
@@ -20,6 +20,7 @@
 import yaml
 from shutil import copyfile
 import os
+import json
 
 
 def load_configuration_variables_from_file(config):
@@ -29,6 +30,18 @@ def load_configuration_variables_from_file(config):
         cofg = yaml.load(f)
     for x, y in cofg.items():
         setattr(config, x, y)
+    if hasattr(config, "verify_certs"):
+        try:
+            verify_certs = json.load(config.verify_certs)
+        except:
+            verify_certs = False
+    else:
+        verify_certs=False
+    config.verify_certs=verify_certs
+    if not verify_certs:
+        import requests
+        from requests.packages.urllib3.exceptions import InsecureRequestWarning
+        requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 
 
 def set_database_connection_variables(config):

--- a/docs/configuration/configuration_installation.rst
+++ b/docs/configuration/configuration_installation.rst
@@ -14,10 +14,12 @@ The application should have the access attributes (e.g, URL, username, password,
       * ``DATABASE_NAME``
       * ``ELASTICSEARCH__URL``
       * ``PAGE_SIZE``
+      * ``ELASTIC_PASSWORD``
     * Although the user can edit this file to set the values, there are some methods inside :omero_search_engine:`manage.py <manage.py>` which could help to set the configuration e.g.
 
       * ``set_database_configuration``
       * ``set_elasticsearch_configuration``
+      * ``set_elasticsearch_password``
 
 * When the app runs for the first time, it will look for the application configuration file.
 

--- a/manage.py
+++ b/manage.py
@@ -191,6 +191,22 @@ def set_elasticsearch_configuration(elasticsearch_url=None):
     else:
         search_omero_app.logger.info("No attribute is provided")
 
+@manager.command
+@manager.option("-e", "--elasticsearch_password", help="set elasticsearch password")
+def set_elasticsearch_password(elasticsearch_password=None):
+    if elasticsearch_password:
+        update_config_file({"ELASTIC_PASSWORD": elasticsearch_password})
+    else:
+        search_omero_app.logger.info("No attribute is provided")
+
+@manager.command
+@manager.option("-v", "--verify_certs", help="set elasticsearch password")
+def set_verify_certs(verify_certs=None):
+    if verify_certs:
+        update_config_file({"verify_certs": verify_certs})
+    else:
+        search_omero_app.logger.info("No attribute is provided")
+
 
 @manager.command
 @manager.option("-c", "--cache_folder", help="cache folder path")

--- a/omero_search_engine/__init__.py
+++ b/omero_search_engine/__init__.py
@@ -22,7 +22,6 @@ import os
 import logging
 from elasticsearch import Elasticsearch
 from flasgger import Swagger, LazyString, LazyJSONEncoder
-import json
 from omero_search_engine.database.database_connector import DatabaseConnector
 from configurations.configuration import (
     configLooader,
@@ -57,6 +56,7 @@ search_omero_app.config["SWAGGER"] = {
 swagger = Swagger(search_omero_app, template=template)
 
 app_config = load_configuration_variables_from_file(config_)
+
 
 def create_app(config_name="development"):
     app_config = configLooader.get(config_name)
@@ -106,6 +106,7 @@ def create_app(config_name="development"):
     search_omero_app.logger.info("app assistant startup")
     return search_omero_app
 
+
 create_app()
 
 from omero_search_engine.api.v1.resources import (  # noqa
@@ -115,6 +116,7 @@ from omero_search_engine.api.v1.resources import (  # noqa
 search_omero_app.register_blueprint(
     resources_routers_blueprint_v1, url_prefix="/api/v1/resources"
 )
+
 
 # add it to account for CORS
 @search_omero_app.after_request


### PR DESCRIPTION
This PR secures the connection between the searchengine and Elasticsearch cluster.
I have tested in `pilot-idr0000-omeroreadwrite` and `test114-searchengine` and it seems to be working fine.
It has been deployed in `Idr-testing`.
This should work with Idr deployment [PR 405](https://github.com/IDR/deployment/pull/405)