### PR TITLE
Add endpoint to return all containers 

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -369,5 +369,12 @@ def update_container_no_of_images():
     update_container_no_of_images()
 
 
+@manager.command
+def get_containers_images_size():
+    from omero_search_engine.cache_functions.elasticsearch.transform_data import (  # noqa
+    update_container_images_size
+    )
+    update_container_images_size()
+
 if __name__ == "__main__":
     manager.run()

--- a/manage.py
+++ b/manage.py
@@ -372,9 +372,11 @@ def update_container_no_of_images():
 @manager.command
 def get_containers_images_size():
     from omero_search_engine.cache_functions.elasticsearch.transform_data import (  # noqa
-    update_container_images_size
+        update_container_images_size,
     )
+
     update_container_images_size()
+
 
 if __name__ == "__main__":
     manager.run()

--- a/manage.py
+++ b/manage.py
@@ -360,5 +360,14 @@ def test_container_key_value():
     check_container_keys_vakues()
 
 
+@manager.command
+def update_container_no_of_images():
+    from omero_search_engine.cache_functions.elasticsearch.transform_data import (  # noqa
+        update_container_no_of_images,
+    )
+
+    update_container_no_of_images()
+
+
 if __name__ == "__main__":
     manager.run()

--- a/omero_search_engine/api/v1/resources/swagger_docs/all_containers.yml
+++ b/omero_search_engine/api/v1/resources/swagger_docs/all_containers.yml
@@ -1,0 +1,9 @@
+A searchengine endpoint to return all the containers (screens and projects).
+---
+tags:
+  - Return all containers
+responses:
+  200:
+    description: A JSON contains the search results
+    examples:
+      results: []

--- a/omero_search_engine/api/v1/resources/urls.py
+++ b/omero_search_engine/api/v1/resources/urls.py
@@ -362,6 +362,16 @@ def submit_query():
         return jsonify(build_error_message(validation_results))
 
 
+@resources.route("/all_containers/", methods=["GET"])
+def get_containers():
+    """
+    file: swagger_docs/all_containers.yml
+    """
+    from utils import get_containers
+
+    return jsonify(get_containers())
+
+
 @resources.route("/<resource_table>/search/", methods=["GET"])
 def search(resource_table):
     """

--- a/omero_search_engine/api/v1/resources/utils.py
+++ b/omero_search_engine/api/v1/resources/utils.py
@@ -1111,9 +1111,7 @@ def get_containers(container_name=""):
     projects_containers = search_resource_annotation("project", query)
     print(screens_containers.keys())
     print(projects_containers.keys())
-    print(len(screens_containers["results"]["results"]))
-    print(len(projects_containers["results"]["results"]))
     data = {}
     data["projects"] = projects_containers["results"]["results"]
-    data["screens"] = projects_containers["results"]["results"]
+    data["screens"] = screens_containers["results"]["results"]
     return data

--- a/omero_search_engine/api/v1/resources/utils.py
+++ b/omero_search_engine/api/v1/resources/utils.py
@@ -159,7 +159,6 @@ should_term_template = Template(
 
 query_template = Template("""{"query": {"bool": {$query}}}""")
 
-
 # This template is added to the query to return the count of an attribute
 count_attr_template = Template(
     """{"key_count": {"terms": {"field": "$field","size": 10000}}}
@@ -1097,3 +1096,24 @@ def adjust_query_for_container(query):
 
         for filter in new_or_filters:
             or_filters.append(filter)
+
+
+def get_containers(container_name=""):
+    query = {
+        "query_details": {},
+        "main_attributes": {
+            "and_main_attributes": [
+                {"name": "name", "value": container_name, "operator": "contains"}
+            ]
+        },
+    }
+    screens_containers = search_resource_annotation("screen", query)
+    projects_containers = search_resource_annotation("project", query)
+    print(screens_containers.keys())
+    print(projects_containers.keys())
+    print(len(screens_containers["results"]["results"]))
+    print(len(projects_containers["results"]["results"]))
+    data = {}
+    data["projects"] = projects_containers["results"]["results"]
+    data["screens"] = projects_containers["results"]["results"]
+    return data

--- a/omero_search_engine/cache_functions/elasticsearch/elasticsearch_templates.py
+++ b/omero_search_engine/cache_functions/elasticsearch/elasticsearch_templates.py
@@ -37,6 +37,7 @@ non_image_template = {
         "properties": {
             "doc_type": {"type": "keyword"},
             "id": {"type": "long"},
+            "container_total_images": {"type": "long"},
             "name": {
                 "type": "text",
                 "fields": {"keyvalue": {"type": "keyword"}},


### PR DESCRIPTION
This PR adds a new endpoint (`/all_containers`) to return all the containers (screens and projects).
Each container has a new key (`container_total_images`) to return the number of images inside each container.
This endpoint should be faster than` /submitquery/containers/`.

This should be used to address using searchengine instead of studies.tsv file for each release, [#41 ](https://github.com/IDR/idr-gallery/pull/41)

This PR has been deployed on the idr-testing, this is the link for the new endpoint:
http://idr-testing.openmicroscopy.org/searchengine/api/v1/resources/all_containers/

@will-moore Could you please check that and let me know what you think

