### PR TITLE
Make Statement timeout configurable 

### DIFF
--- a/configurations/app_config.yml
+++ b/configurations/app_config.yml
@@ -14,3 +14,4 @@ MAX_RETUNED_ITEMS : 1700000
 ELASTICSEARCH_BACKUP_FOLDER: "path/to/elasticsearch/backup/folder"
 verify_certs: False
 ELASTIC_PASSWORD: elasticsearch_user_password
+STATEMENT_TIMEOUT: 5000

--- a/manage.py
+++ b/manage.py
@@ -272,6 +272,13 @@ def set_no_processes(no_processes=None):
     else:
         search_omero_app.logger.info("No valid attribute is provided")
 
+@manager.command
+@manager.option("-t", "--time_out", help="database time out in ms")
+def set_database_timeout(time_out=None):
+    if time_out and time_out.isdigit():
+        update_config_file({"STATEMENT_TIMEOUT": int(time_out)})
+    else:
+        search_omero_app.logger.info("No valid attribute is provided")
 
 @manager.command
 @manager.option(

--- a/omero_search_engine/cache_functions/elasticsearch/sql_to_csv.py
+++ b/omero_search_engine/cache_functions/elasticsearch/sql_to_csv.py
@@ -177,7 +177,8 @@ def get_images_dataset_project(ids):
          datasetimagelink.child in ({ids})".format(
         ids=ids
     )
-    results = search_omero_app.config["database_connector"].execute_query(sql)
+    statement_timeout = search_omero_app.config["STATEMENT_TIMEOUT"]
+    results = search_omero_app.config["database_connector"].execute_query(sql,statement_timeout=statement_timeout)
     return results
 
 
@@ -194,7 +195,8 @@ def get_images_plates_screens(ids):
            where wellsample.image in ({ids})".format(
         ids=ids
     )
-    results = search_omero_app.config["database_connector"].execute_query(sql)
+    statement_timeout = search_omero_app.config["STATEMENT_TIMEOUT"]
+    results = search_omero_app.config["database_connector"].execute_query(sql,statement_timeout=statement_timeout)
     screens = []
     plates = []
     for res in results:
@@ -210,7 +212,8 @@ def create_csv_for_images(folder):
     Query database to get the image data then save them to multiple CSV files
     """
     conn = search_omero_app.config["database_connector"]
-    image_data = conn.execute_query(image_sql)
+    statement_timeout = search_omero_app.config["STATEMENT_TIMEOUT"]
+    image_data = conn.execute_query(image_sql,statement_timeout=statement_timeout)
     total_records = len(image_data)
     file_size = 2200000
 

--- a/omero_search_engine/cache_functions/elasticsearch/transform_data.py
+++ b/omero_search_engine/cache_functions/elasticsearch/transform_data.py
@@ -449,7 +449,8 @@ def get_insert_data_to_index(sql_st, resource):
     delete_index(resource)
     create_omero_indexes(resource)
     sql_ = "select max (id) from %s" % resource
-    res2 = search_omero_app.config["database_connector"].execute_query(sql_)
+    statement_timeout = search_omero_app.config["STATEMENT_TIMEOUT"]
+    res2 = search_omero_app.config["database_connector"].execute_query(sql_,statement_timeout=statement_timeout)
     max_id = res2[0]["max"]
     page_size = search_omero_app.config["CACHE_ROWS"]
     start_time = datetime.now()
@@ -523,7 +524,8 @@ def processor_work(lock, global_counter, val):
         "Calling the databas for %s/%s" % (global_counter.value, total_process)
     )
     conn = search_omero_app.config["database_connector"]
-    results = conn.execute_query(mod_sql)
+    statement_timeout = search_omero_app.config["STATEMENT_TIMEOUT"]
+    results = conn.execute_query(mod_sql,statement_timeout=statement_timeout)
     search_omero_app.logger.info("Processing the results...")
     process_results(results, resource, lock)
     average_time = (datetime.now() - st) / 2
@@ -678,7 +680,8 @@ def save_key_value_buckets(
                 resource=resource_table
             )
             conn = search_omero_app.config["database_connector"]
-            name_result = conn.execute_query(sql)
+            statement_timeout = search_omero_app.config["STATEMENT_TIMEOUT"]
+            name_result = conn.execute_query(sql,statement_timeout=statement_timeout)
             # name_results = [res["name"] for res in name_results]
             # Determine the number of images for each container
             for res in name_result:
@@ -687,7 +690,7 @@ def save_key_value_buckets(
                     sql_n = query_images_in_project_id.substitute(project_id=id)
                 elif resource_table == "screen":
                     sql_n = query_images_screen_id.substitute(screen_id=id)
-                no_images_co = conn.execute_query(sql_n)
+                no_images_co = conn.execute_query(sql_n,statement_timeout=statement_timeout)
                 res["no_images"] = len(no_images_co)
 
             name_results = [
@@ -792,7 +795,8 @@ def get_keys(res_table):
            annotation_mapvalue.annotation_id".format(
         res_table=res_table
     )
-    results = search_omero_app.config["database_connector"].execute_query(sql)
+    statement_timeout = search_omero_app.config["STATEMENT_TIMEOUT"]
+    results = search_omero_app.config["database_connector"].execute_query(sql,statement_timeout=statement_timeout)
     results = [res["name"] for res in results]
     return results
 

--- a/omero_search_engine/database/database_connector.py
+++ b/omero_search_engine/database/database_connector.py
@@ -53,7 +53,7 @@ class DatabaseConnector(object):
         self.session = Session()
         self.session._model_changes = {}
 
-    def execute_query(self, query, return_results=True):
+    def execute_query(self, query,statement_timeout=5000, return_results=True):
         results = {}
         conn = psycopg2.connect(
             self.DATABASE_URI
@@ -61,7 +61,7 @@ class DatabaseConnector(object):
         try:
             with conn:
                 with conn.cursor(cursor_factory=RealDictCursor) as cursor:
-                    cursor.execute("SET statement_timeout = '5000 s'")
+                    cursor.execute("SET statement_timeout = '%s s'"%statement_timeout)
                     cursor.execute(query)
                     if return_results:
                         results = cursor.fetchall()

--- a/omero_search_engine/validation/results_validator.py
+++ b/omero_search_engine/validation/results_validator.py
@@ -93,7 +93,9 @@ class Validator(object):
                 values = "'%s'" % claus[1].lower()
         sql = query_methods[name].substitute(names=names, values=values)
         conn = search_omero_app.config["database_connector"]
-        postgres_results = conn.execute_query(sql)
+        statement_timeout=search_omero_app.config["STATEMENT_TIMEOUT"]
+        postgres_results = conn.execute_query(sql,statement_timeout=statement_timeout)
+
         results = [item["id"] for item in postgres_results]
         search_omero_app.logger.info(
             "results for or received %s" % len(results)
@@ -108,7 +110,8 @@ class Validator(object):
                 name=claus[0].lower(), value=claus[1].lower()
             )
             conn = search_omero_app.config["database_connector"]
-            postgres_results = conn.execute_query(sql)
+            statement_timeout=search_omero_app.config["STATEMENT_TIMEOUT"]
+            postgres_results = conn.execute_query(sql, statement_timeout=statement_timeout)
             res = [item["id"] for item in postgres_results]
             search_omero_app.logger.info(
                 "results for and  received recived %s" % len(res)
@@ -149,7 +152,8 @@ class Validator(object):
                 sql = self.sql_statement.substitute(name=self.value)
         # search_omero_app.logger.info ("sql: %s"%sql)
         conn = search_omero_app.config["database_connector"]
-        postgres_results = conn.execute_query(sql)
+        statement_timeout = search_omero_app.config["STATEMENT_TIMEOUT"]
+        postgres_results = conn.execute_query(sql, statement_timeout=statement_timeout)
         self.postgres_results = [item["id"] for item in postgres_results]
         search_omero_app.logger.info(
             "results received %s" % len(self.postgres_results)
@@ -309,8 +313,9 @@ class Validator(object):
             key=self.name, value=self.value
         )
         conn = search_omero_app.config["database_connector"]
-        screens_results = conn.execute_query(screens_count_sql)
-        projects_results = conn.execute_query(projects_count_sql)
+        statement_timeout = search_omero_app.config["STATEMENT_TIMEOUT"]
+        screens_results = conn.execute_query(screens_count_sql,statement_timeout=statement_timeout)
+        projects_results = conn.execute_query(projects_count_sql, statement_timeout=statement_timeout)
         screens_results_idr = [item["name"] for item in screens_results]
         projects_results_idr = [item["name"] for item in projects_results]
         search_engine_results = simple_search(
@@ -694,6 +699,7 @@ def get_no_images_sql_containers():
     from omero_search_engine.api.v1.resources.utils import adjust_query_for_container
 
     conn = search_omero_app.config["database_connector"]
+    statement_timeout = search_omero_app.config["STATEMENT_TIMEOUT"]
 
     all_names = get_resource_names("all")
     messages = []
@@ -731,7 +737,7 @@ def get_no_images_sql_containers():
             search_omero_app.logger.info(message2)
             messages.append(message2)
             sql = query_methods["%s_name" % resource].substitute(name=res_name)
-            results = conn.execute_query(sql)
+            results = conn.execute_query(sql,statement_timeout=statement_timeout)
             postgres_results = len(results)
             message3 = "No of images returned from postgresql: %s" % seachengine_results
             messages.append(message3)
@@ -782,8 +788,9 @@ def check_container_keys_vakues():
                 container="screen", name=container_name
             )
             conn = search_omero_app.config["database_connector"]
-            project_ids_results = conn.execute_query(project_sql)
-            screen_ids_results = conn.execute_query(screen_sql)
+            statement_timeout = search_omero_app.config["STATEMENT_TIMEOUT"]
+            project_ids_results = conn.execute_query(project_sql,statement_timeout=statement_timeout)
+            screen_ids_results = conn.execute_query(screen_sql,statement_timeout=statement_timeout)
 
             search_omero_app.logger.info("projects: %s" % project_ids_results)
             search_omero_app.logger.info("screens: %s" % screen_ids_results)
@@ -791,7 +798,7 @@ def check_container_keys_vakues():
             if len(screen_ids_results) > 0:
                 for id in screen_ids_results:
                     screen_sql = screen_key_values.substitute(id=id.get("id"), name=key)
-                    screen_results = conn.execute_query(screen_sql)
+                    screen_results = conn.execute_query(screen_sql,statement_timeout=statement_timeout)
                     scr_searchengine_results = get_container_values_for_key(
                         "image", container_name, csv, key
                     )
@@ -820,7 +827,7 @@ def check_container_keys_vakues():
                     project_sql = project_key_values.substitute(
                         id=id.get("id"), name=key
                     )
-                    project_results = conn.execute_query(project_sql)
+                    project_results = conn.execute_query(project_sql,statement_timeout=statement_timeout)
                     pr_searchengine_results = get_container_values_for_key(
                         "image", container_name, csv, key
                     )

--- a/unit_tests/test_app.py
+++ b/unit_tests/test_app.py
@@ -91,7 +91,8 @@ class BasicTestCase(unittest.TestCase):
         """
         test connection with postgresql database
         """
-        res = search_omero_app.config["database_connector"].execute_query(sql)
+        statement_timeout = search_omero_app.config["STATEMENT_TIMEOUT"]
+        res = search_omero_app.config["database_connector"].execute_query(sql,statement_timeout=statement_timeout)
         self.assertIsNotNone(res)
         self.assertEqual(res[0]["current_database"], "omero")
 


### PR DESCRIPTION
This PR allows the user to configure the database statement timeout by setting `STATEMENT_TIMEOUT` attribute in the app configuration file. The user can use a `manage.py` method (`set_database_timeout`) to configure this attribute 
