### PR TITLE
Address issue #39

### DIFF
--- a/omero_search_engine/api/v1/resources/resource_analyser.py
+++ b/omero_search_engine/api/v1/resources/resource_analyser.py
@@ -1003,12 +1003,24 @@ containers_no_images = Template(
 )
 
 
-def get_containers_no_images(contianer, container_name, query_details=None):
+def get_containers_no_images(container_name, query_details=None):
+    contianer = None
     containers_subcontainers = {"project": "dataset", "screen": "plate"}
+    act_names = get_containets_from_name(container_name)
+    for res, item in act_names.items():
+        print(res, item)
+        if len(item) == 0:
+            continue
+        elif len(item) == 1:
+            print(res)
+            contianer = res
+            container_name = item[0]["name"]
+    if not contianer:
+        return "Container %s is not found" % container_name
     if contianer.lower() in containers_subcontainers:
         sub_container = containers_subcontainers[contianer.lower()]
     else:
-        return "Container %s is not supported"%contianer
+        return "Container %s is not supported" % contianer
     res_index = resource_elasticsearchindex.get("image")
     aggs_part = container_returned_sub_container_template.substitute(
         container_attribute_name="%s_name.keyvalue" % contianer,

--- a/omero_search_engine/api/v1/resources/resource_analyser.py
+++ b/omero_search_engine/api/v1/resources/resource_analyser.py
@@ -934,7 +934,6 @@ container_project_values_key_template = Template(
    {"terms": {"field": "key_values.value.keyvalue","size": 10000}}}}}}}"""
 )
 
-
 """
 Get all the keys bucket"""
 container_project_keys_template = {
@@ -1005,13 +1004,10 @@ containers_no_images = Template(
 
 
 def get_containers_no_images(
-    contianer, container_name, sub_container=None, query_details=None
+    contianer, container_name, query_details=None
 ):
     containers_subcontainers = {"project": "dataset", "screen": "plate"}
-    if not sub_container:
-        if not containers_subcontainers.get(contianer.lower()):
-            return "No sub container is found, please check the container type"
-        sub_container = containers_subcontainers[contianer]
+    sub_container = containers_subcontainers[contianer]
     res_index = resource_elasticsearchindex.get("image")
     aggs_part = container_returned_sub_container_template.substitute(
         container_attribute_name="%s_name.keyvalue" % contianer,
@@ -1024,7 +1020,7 @@ def get_containers_no_images(
         and_filters = query_details.get("and_filters")
         or_filters = query_details.get("or_filters")
         case_sensitive = query_details.get("case_sensitive")
-        main_attributes = query.get("main_attributes")
+        main_attributes = query_details.get("main_attributes")
         from omero_search_engine.api.v1.resources.utils import (
             elasticsearch_query_builder,
         )
@@ -1038,8 +1034,6 @@ def get_containers_no_images(
     query["aggs"] = json.loads(aggs_part)
     res = search_index_for_value(res_index, query)
     buckets = res["aggregations"]["values"]["uniquesTerms"]["buckets"]
-    print(len(buckets))
-    print(buckets[0])
     returned_results = []
     for bucket in buckets:
         returned_results.append(

--- a/omero_search_engine/api/v1/resources/resource_analyser.py
+++ b/omero_search_engine/api/v1/resources/resource_analyser.py
@@ -1003,9 +1003,7 @@ containers_no_images = Template(
 )
 
 
-def get_containers_no_images(
-    contianer, container_name, query_details=None
-):
+def get_containers_no_images(contianer, container_name, query_details=None):
     containers_subcontainers = {"project": "dataset", "screen": "plate"}
     sub_container = containers_subcontainers[contianer]
     res_index = resource_elasticsearchindex.get("image")

--- a/omero_search_engine/api/v1/resources/resource_analyser.py
+++ b/omero_search_engine/api/v1/resources/resource_analyser.py
@@ -1005,7 +1005,10 @@ containers_no_images = Template(
 
 def get_containers_no_images(contianer, container_name, query_details=None):
     containers_subcontainers = {"project": "dataset", "screen": "plate"}
-    sub_container = containers_subcontainers[contianer]
+    if contianer.lower() in containers_subcontainers:
+        sub_container = containers_subcontainers[contianer.lower()]
+    else:
+        return "Container %s is not supported"%contianer
     res_index = resource_elasticsearchindex.get("image")
     aggs_part = container_returned_sub_container_template.substitute(
         container_attribute_name="%s_name.keyvalue" % contianer,

--- a/omero_search_engine/api/v1/resources/swagger_docs/container_filterkeyvalues.yml
+++ b/omero_search_engine/api/v1/resources/swagger_docs/container_filterkeyvalues.yml
@@ -20,7 +20,7 @@ The query:
           "value": "Brain",
           "operator": "equals",
           "resource": "image"
-        },
+        }
       ],
       "or_filters": [
 

--- a/omero_search_engine/api/v1/resources/swagger_docs/container_filterkeyvalues.yml
+++ b/omero_search_engine/api/v1/resources/swagger_docs/container_filterkeyvalues.yml
@@ -1,0 +1,69 @@
+Return the available key values within a container which within a query results
+Example
+
+In this example the search will use the provided query results within the specified container and provides the aviable values for the provided key.
+
+The query:
+
+{
+  "resource": "image",
+    "query_details": {
+      "and_filters": [
+        {
+          "name": "Organism",
+          "value": "homo sapiens",
+          "operator": "equals",
+          "resource": "image"
+        },
+        {
+          "name": "Organism part",
+          "value": "Brain",
+          "operator": "equals",
+          "resource": "image"
+        },
+      ],
+      "or_filters": [
+
+      ],
+      "case_sensitive": false
+    }
+  }
+
+The user needs to specify
+- the container name, e.g. "idr0043-uhlen-humanproteinatlas/experimentA"
+- the key which its values is needed, e.g. "gene symbol"
+
+the results should contains buckets like this:
+{
+        "key": "Gene symbol",
+        "no_image": 146,
+        "value": "NBPF12"
+}
+---
+tags:
+ - Return available key values with a search results in a container
+parameters:
+  - name: resource_table
+    in: path
+    type: string
+    enum: ['image', 'project', 'screen', 'well', 'plate']
+    required: true
+    default: 'image'
+  - name: data
+    in: body
+    required: true
+  - name: container_name
+    in: query
+    type: string
+    required: true
+
+  - name: key
+    in: query
+    type: string
+    required: true
+
+responses:
+  200:
+    description: A JSON contains the results
+    examples:
+      results: []

--- a/omero_search_engine/api/v1/resources/swagger_docs/container_images.yml
+++ b/omero_search_engine/api/v1/resources/swagger_docs/container_images.yml
@@ -1,0 +1,10 @@
+A searchengine endpoint to Return the available containers and the number of images in each.
+---
+tags:
+  - Containers and the number of images in each.
+
+responses:
+  200:
+    description: A JSON contains the search results
+    examples:
+      results: []

--- a/omero_search_engine/api/v1/resources/swagger_docs/sub_container_images.yml
+++ b/omero_search_engine/api/v1/resources/swagger_docs/sub_container_images.yml
@@ -31,17 +31,12 @@ This a query example:
   }
 }
 and the user should provide the container nane, e.g,idr0043-uhlen-humanproteinatlas/experimentA
-and the container type which is project
+
 This will return the dataset inside the project with several images in each, this is within the search results.
 ---
 tags:
   - Available sub-containers inside a container
 parameters:
-  - name: container
-    in: query
-    type: string
-    enum: ['project', 'screen']
-    required: true
   - name: container_name
     description: The container name
     in: query

--- a/omero_search_engine/api/v1/resources/swagger_docs/sub_container_images.yml
+++ b/omero_search_engine/api/v1/resources/swagger_docs/sub_container_images.yml
@@ -1,0 +1,25 @@
+A searchengine endpoint to return the available sub-container in a container (e.g. dataset in project)
+A query can be provided to return only the search results
+---
+tags:
+  - Available sub-containers inside a container
+parameters:
+  - name: container
+    in: query
+    type: string
+    enum: ['project', 'screen']
+    required: true
+  - name: container_name
+    description: The container name
+    in: query
+    type: string
+    required: true
+  - name: data
+    in: body
+    required: false
+
+responses:
+  200:
+    description: A JSON contains the search results
+    examples:
+      results: []

--- a/omero_search_engine/api/v1/resources/swagger_docs/sub_container_images.yml
+++ b/omero_search_engine/api/v1/resources/swagger_docs/sub_container_images.yml
@@ -1,5 +1,38 @@
-A searchengine endpoint to return the available sub-container in a container (e.g. dataset in project)
-A query can be provided to return only the search results
+A searchengine endpoint to return the available sub-container in a container (e.g. dataset in project).
+A query can be provided to return only the search results.
+This a query example:
+{
+  "resource": "image",
+  "query_details": {
+    "and_filters": [
+      {
+        "name": "Organism",
+        "value": "homo sapiens",
+        "operator": "equals",
+        "resource": "image"
+      },
+      {
+        "name": "Gene symbol",
+        "value": "AC240274.1",
+        "operator": "contains",
+        "resource": "image"
+      },
+      {
+        "name": "Organism part",
+        "value": "Brain",
+        "operator": "equals",
+        "resource": "image"
+      }
+    ],
+    "or_filters": [
+
+    ],
+    "case_sensitive": false
+  }
+}
+and the user should provide the container nane, e.g,idr0043-uhlen-humanproteinatlas/experimentA
+and the container type which is project
+This will return the dataset inside the project with several images in each, this is within the search results.
 ---
 tags:
   - Available sub-containers inside a container

--- a/omero_search_engine/api/v1/resources/urls.py
+++ b/omero_search_engine/api/v1/resources/urls.py
@@ -469,8 +469,8 @@ def container_keys_search(resource_table):
 @resources.route("/container_images/", methods=["GET"])
 def container_images():
     """
-      file: swagger_docs/container_images.yml
-      """
+    file: swagger_docs/container_images.yml
+    """
     from omero_search_engine.api.v1.resources.resource_analyser import (
         return_containes_images,
     )
@@ -479,11 +479,11 @@ def container_images():
 
 
 # to do: add query to return the results withiz the sub-container
-@resources.route("/sub_container_images/", methods=["POST","GET"])
+@resources.route("/sub_container_images/", methods=["POST", "GET"])
 def sub_container_images():
     """
-       file: swagger_docs/sub_container_images.yml
-     """
+    file: swagger_docs/sub_container_images.yml
+    """
     from omero_search_engine.api.v1.resources.resource_analyser import (
         get_containers_no_images,
     )
@@ -497,7 +497,7 @@ def sub_container_images():
             )
         )
     data = request.data
-    query={}
+    query = {}
     if data:
         try:
             data = json.loads(data)

--- a/omero_search_engine/api/v1/resources/urls.py
+++ b/omero_search_engine/api/v1/resources/urls.py
@@ -464,3 +464,24 @@ def container_keys_search(resource_table):
             csv = False
     results = get_container_values_for_key(resource_table, container_name, csv)
     return results
+
+
+@resources.route("/container_images/", methods=["GET"])
+def container_images():
+    from omero_search_engine.api.v1.resources.resource_analyser import (
+        return_containes_images,
+    )
+
+    return return_containes_images()
+
+
+# to do: add query to return the results withiz the sub-container
+@resources.route("/sub_container_images/", methods=["GET"])
+def sub_container_images():
+    from omero_search_engine.api.v1.resources.resource_analyser import (
+        get_containers_no_images,
+    )
+
+    container = request.args.get("container")
+    container_name = request.args.get("container_name")
+    return get_containers_no_images(container, container_name)

--- a/omero_search_engine/api/v1/resources/urls.py
+++ b/omero_search_engine/api/v1/resources/urls.py
@@ -389,6 +389,37 @@ def search(resource_table):
     return jsonify(results)
 
 
+@resources.route("/<resource_table>/container_filterkeyvalues/", methods=["POST"])
+def container_key_values_filter(resource_table):
+    """
+    file: swagger_docs/container_filterkeyvalues.yml
+    """
+    from omero_search_engine.api.v1.resources.resource_analyser import (
+        get_container_values_for_key,
+    )
+
+    key = request.args.get("key")
+    container_name = request.args.get("container_name")
+    if not container_name or not key:
+        return build_error_message("Container name and key are required")
+
+    data = request.data
+    try:
+        query = json.loads(data)
+    except Exception:
+        return jsonify(
+            build_error_message(
+                "{error}".format(error="No proper query data is provided ")
+            )
+        )
+    validation_results = query_validator(query)
+    if validation_results != "OK":
+        return jsonify(build_error_message(validation_results))
+    return get_container_values_for_key(
+        resource_table, container_name, None, key, query
+    )
+
+
 @resources.route("/<resource_table>/container_keyvalues/", methods=["GET"])
 def container_key_values_search(resource_table):
     """

--- a/omero_search_engine/api/v1/resources/urls.py
+++ b/omero_search_engine/api/v1/resources/urls.py
@@ -479,7 +479,7 @@ def container_images():
 
 
 # to do: add query to return the results withiz the sub-container
-@resources.route("/sub_container_images/", methods=["POST", "GET"])
+@resources.route("/sub_container_images/", methods=["POST"])
 def sub_container_images():
     """
     file: swagger_docs/sub_container_images.yml
@@ -488,13 +488,10 @@ def sub_container_images():
         get_containers_no_images,
     )
 
-    container = request.args.get("container")
     container_name = request.args.get("container_name")
-    if not container_name or not container:
+    if not container_name:
         return jsonify(
-            build_error_message(
-                "{error}".format(error="container and container name are required.")
-            )
+            build_error_message("{error}".format(error="Container name is required."))
         )
     data = request.data
     query = {}
@@ -507,8 +504,6 @@ def sub_container_images():
                     "{error}".format(error="No proper query data is provided.")
                 )
             )
-
         if "query_details" in data:
-            query = data["query_details "]
-
-    return get_containers_no_images(container, container_name, query)
+            query = data["query_details"]
+    return get_containers_no_images(container_name, query)

--- a/omero_search_engine/api/v1/resources/urls.py
+++ b/omero_search_engine/api/v1/resources/urls.py
@@ -468,6 +468,9 @@ def container_keys_search(resource_table):
 
 @resources.route("/container_images/", methods=["GET"])
 def container_images():
+    """
+      file: swagger_docs/container_images.yml
+      """
     from omero_search_engine.api.v1.resources.resource_analyser import (
         return_containes_images,
     )
@@ -476,12 +479,36 @@ def container_images():
 
 
 # to do: add query to return the results withiz the sub-container
-@resources.route("/sub_container_images/", methods=["GET"])
+@resources.route("/sub_container_images/", methods=["POST","GET"])
 def sub_container_images():
+    """
+       file: swagger_docs/sub_container_images.yml
+     """
     from omero_search_engine.api.v1.resources.resource_analyser import (
         get_containers_no_images,
     )
 
     container = request.args.get("container")
     container_name = request.args.get("container_name")
-    return get_containers_no_images(container, container_name)
+    if not container_name or not container:
+        return jsonify(
+            build_error_message(
+                "{error}".format(error="container and container name are required.")
+            )
+        )
+    data = request.data
+    query={}
+    if data:
+        try:
+            data = json.loads(data)
+        except Exception:
+            return jsonify(
+                build_error_message(
+                    "{error}".format(error="No proper query data is provided.")
+                )
+            )
+
+        if "query_details" in data:
+            query = data["query_details "]
+
+    return get_containers_no_images(container, container_name, query)

--- a/omero_search_engine/api/v1/resources/utils.py
+++ b/omero_search_engine/api/v1/resources/utils.py
@@ -1040,8 +1040,13 @@ def search_resource_annotation(
                 return query_string
 
             search_omero_app.logger.info("Query %s" % query_string)
-            query = json.loads(query_string, strict=False)
-            raw_query_to_send_back = json.loads(query_string, strict=False)
+            from ast import literal_eval
+
+            try:
+                query = literal_eval(query_string)
+                raw_query_to_send_back = literal_eval(query_string)
+            except Exception as ex:
+                raise Exception("Failed to load the query, error: %s" % str(ex))
         else:
             query = raw_elasticsearch_query
             raw_query_to_send_back = copy.copy(raw_elasticsearch_query)


### PR DESCRIPTION
This PR addresses issue  #39,  i.e. the searchengine will use the provided query results within the specified container and give the available values for a key within these results.
There is a new endpoint `/<resource_table>/container_filterkeyvalues/` in which the users should provide the query, i.e.:
```
{
   "resource":"image",
   "query_details":{
      "and_filters":[
         {
            "name":"Organism",
            "value":"homo sapiens",
            "operator":"equals",
            "resource":"image"
         }
      ],
      "or_filters":[
         
      ],
      "case_sensitive":false
   }
}
```

The user needs also to provide the following two parameters:
- the `container` name, e.g. `idr0043-uhlen-humanproteinatlas/experimentA`
- the `key `which its values is needed, e.g. "`Organism Part`"

the results should contain buckets like this:
```
  {
        "key": "Organism Part",
        "no_image": 220751,
        "value": "Brain"
   },
```

If the user wants to get the available `Gene Symbol` values in one particular "Organism Part"  e.g. `Brain`, the query should be like this:

```
{
   "resource":"image",
   "query_details":{
      "and_filters":[
         {
            "name":"Organism",
            "value":"homo sapiens",
            "operator":"equals",
            "resource":"image"
         },
         {
            "name":"Organism part",
            "value":"Brain",
            "operator":"equals",
            "resource":"image"
         }    
      ],
      "or_filters":[
         
      ],
      "case_sensitive":false
   }
}
```

The provided `key ` value should be `Gene Symbol`  and the `container` name should be the same.

I will deploy it on idr-testing once it is up.
cc @will-moore,