### PR TITLE
Query results bff format

### DIFF
--- a/omero_search_engine/api/v1/resources/swagger_docs/search.yml
+++ b/omero_search_engine/api/v1/resources/swagger_docs/search.yml
@@ -41,6 +41,11 @@ parameters:
     in: query
     type: boolean
     required: false
+  - name: return_bff
+    description: return csv file with BFF format
+    in: query
+    type: boolean
+    required: false
   - name: data_source
     in: query
     type: string

--- a/omero_search_engine/api/v1/resources/swagger_docs/submitquery.yml
+++ b/omero_search_engine/api/v1/resources/swagger_docs/submitquery.yml
@@ -100,6 +100,10 @@ parameters:
     description: return additional columns to help display the results in a table
     in: query
     type: boolean
+  - name: return_bff
+    description: return csv file with BFF format
+    in: query
+    type: boolean
     required: false
   - name: data
     in: body

--- a/omero_search_engine/api/v1/resources/urls.py
+++ b/omero_search_engine/api/v1/resources/urls.py
@@ -638,7 +638,8 @@ def container_key_values_filter(resource_table):
         query=query,
     )
 
-'''
+
+"""
 @resources.route("/search_bff_query/", methods=["GET"])
 def bff_query():
     import jsonurl_py as jsonurl
@@ -652,5 +653,5 @@ def bff_query():
     print(query)
     return jsonify(query)
 
-'''
+"""
 # (((key:Gene+Symbol,value:pdxk,operator:equals,resource:image),(key:Gene+Symbol,value:pdxp,operator:equals,resource:image)),(key:Publication+Title,value:rnf168+binds+and+amplifies+ubiquitin+conjugates+on+damaged+chromosomes+to+allow+accumulation+of+repair+proteins.,operator:contains,resource:container),(key:Organism,value:homo+sapiens,operator:equals,resource:container))

--- a/omero_search_engine/api/v1/resources/urls.py
+++ b/omero_search_engine/api/v1/resources/urls.py
@@ -638,7 +638,7 @@ def container_key_values_filter(resource_table):
         query=query,
     )
 
-
+'''
 @resources.route("/search_bff_query/", methods=["GET"])
 def bff_query():
     import jsonurl_py as jsonurl
@@ -652,5 +652,5 @@ def bff_query():
     print(query)
     return jsonify(query)
 
-
+'''
 # (((key:Gene+Symbol,value:pdxk,operator:equals,resource:image),(key:Gene+Symbol,value:pdxp,operator:equals,resource:image)),(key:Publication+Title,value:rnf168+binds+and+amplifies+ubiquitin+conjugates+on+damaged+chromosomes+to+allow+accumulation+of+repair+proteins.,operator:contains,resource:container),(key:Organism,value:homo+sapiens,operator:equals,resource:container))

--- a/omero_search_engine/api/v1/resources/utils.py
+++ b/omero_search_engine/api/v1/resources/utils.py
@@ -1795,7 +1795,7 @@ def write_BBF(results, file_name=None, return_contents=False):
     print(len(lines))
 
 
-def create_bff_file_response(file_contents, bookmark, paginationm, resource):
+def create_bff_file_response(file_contents, bookmark, pagination, resource):
     file_name = "bff"
     return Response(
         file_contents,
@@ -1804,7 +1804,7 @@ def create_bff_file_response(file_contents, bookmark, paginationm, resource):
             "Content-disposition": "attachment; filename=%s_%s.csv"
             % (file_name, resource),
             "bookmark": bookmark,
-            "paginationm": paginationm,
+            "pagination": pagination,
         },
     )
 

--- a/omero_search_engine/api/v1/resources/utils.py
+++ b/omero_search_engine/api/v1/resources/utils.py
@@ -28,6 +28,7 @@ import time
 from omero_search_engine import search_omero_app
 from string import Template
 from app_data.data_attrs import annotation_resource_link
+from flask import  Response
 
 contain_list = ["contains", "not_contains"]
 main_dir = os.path.abspath(os.path.dirname(__file__))
@@ -1724,8 +1725,11 @@ def delete_data_source_contents(data_source):
     return found
 
 
-def write_BBF(results, resource, file_name):
+def write_BBF(results, file_name=None, return_contents=False):
     import pandas as pd
+    print("=====================================")
+    print (type(results))
+    print ("=====================================")
 
     to_ignore_list = {
         "project": [
@@ -1763,7 +1767,15 @@ def write_BBF(results, resource, file_name):
     for row_ in results:
         line = {}
         lines.append(line)
+        print (row_)
+        print ("========================")
+        if row_.get("project_id"):
+            resource="project"
+        else:
+            resource="screen"
         for name, item in row_.items():
+            print (name)
+            print ("###############################")
             if name in to_ignore_list[resource]:
                 continue
             if name == "key_values" and len(item) > 0:
@@ -1776,9 +1788,22 @@ def write_BBF(results, resource, file_name):
                     line[name] = item
 
     df = pd.DataFrame(lines)
+    if return_contents:
+        return df.to_csv()
     df.to_csv(file_name)
     print(len(lines))
 
+
+def create_bff_file_response(file_contents,resource):
+    file_name = "bff"
+    return Response(
+        file_contents,
+        mimetype="text/csv",
+        headers={
+            "Content-disposition": "attachment; filename=%s_%s.csv"
+                                   % (file_name, resource)
+        },
+    )
 
 delete_container_query = Template(
     """

--- a/omero_search_engine/api/v1/resources/utils.py
+++ b/omero_search_engine/api/v1/resources/utils.py
@@ -28,7 +28,7 @@ import time
 from omero_search_engine import search_omero_app
 from string import Template
 from app_data.data_attrs import annotation_resource_link
-from flask import  Response
+from flask import Response
 
 contain_list = ["contains", "not_contains"]
 main_dir = os.path.abspath(os.path.dirname(__file__))
@@ -1727,9 +1727,10 @@ def delete_data_source_contents(data_source):
 
 def write_BBF(results, file_name=None, return_contents=False):
     import pandas as pd
+
     print("=====================================")
-    print (type(results))
-    print ("=====================================")
+    print(type(results))
+    print("=====================================")
 
     to_ignore_list = {
         "project": [
@@ -1767,15 +1768,15 @@ def write_BBF(results, file_name=None, return_contents=False):
     for row_ in results:
         line = {}
         lines.append(line)
-        print (row_)
-        print ("========================")
+        print(row_)
+        print("========================")
         if row_.get("project_id"):
-            resource="project"
+            resource = "project"
         else:
-            resource="screen"
+            resource = "screen"
         for name, item in row_.items():
-            print (name)
-            print ("###############################")
+            print(name)
+            print("###############################")
             if name in to_ignore_list[resource]:
                 continue
             if name == "key_values" and len(item) > 0:
@@ -1794,16 +1795,19 @@ def write_BBF(results, file_name=None, return_contents=False):
     print(len(lines))
 
 
-def create_bff_file_response(file_contents,resource):
+def create_bff_file_response(file_contents, bookmark, paginationm, resource):
     file_name = "bff"
     return Response(
         file_contents,
         mimetype="text/csv",
         headers={
             "Content-disposition": "attachment; filename=%s_%s.csv"
-                                   % (file_name, resource)
+            % (file_name, resource),
+            "bookmark": bookmark,
+            "paginationm": paginationm,
         },
     )
+
 
 delete_container_query = Template(
     """

--- a/omero_search_engine/api/v1/resources/utils.py
+++ b/omero_search_engine/api/v1/resources/utils.py
@@ -1724,6 +1724,62 @@ def delete_data_source_contents(data_source):
     return found
 
 
+def write_BBF(results, resource, file_name):
+    import pandas as pd
+
+    to_ignore_list = {
+        "project": [
+            "dataset_id",
+            "dataset_name",
+            "doc_type",
+            "experiment",
+            "group_id",
+            "image_size",
+            "owner_id",
+            "plate_id",
+            "plate_name",
+            "screen_name",
+            "screen_id",
+            "well_id",
+            "wellsample_id",
+        ],
+        "screen": [
+            "dataset_id",
+            "dataset_name",
+            "doc_type",
+            "experiment",
+            "group_id",
+            "image_size",
+            "owner_id",
+            "dataset_name",
+            "project_id",
+            "project_name",
+            "well_id",
+            "wellsample_id",
+        ],
+    }
+    col_converter = {"image_url": "File Path", "thumb_url": "Thumbnail"}
+    lines = []
+    for row_ in results:
+        line = {}
+        lines.append(line)
+        for name, item in row_.items():
+            if name in to_ignore_list[resource]:
+                continue
+            if name == "key_values" and len(item) > 0:
+                for row in item:
+                    line[row["name"]] = row["value"]
+            else:
+                if name in col_converter:
+                    line[col_converter[name]] = item
+                else:
+                    line[name] = item
+
+    df = pd.DataFrame(lines)
+    df.to_csv(file_name)
+    print(len(lines))
+
+
 delete_container_query = Template(
     """
 {"query":{

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,4 +33,4 @@ wcwidth==0.2.5
 Werkzeug==1.0.1
 bump2version==1.0.1
 watchdog==6.0.0
-jsonurl-py==-0.4.0
+#jsonurl-py==-0.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,3 +33,4 @@ wcwidth==0.2.5
 Werkzeug==1.0.1
 bump2version==1.0.1
 watchdog==6.0.0
+jsonurl-py==-0.4.0


### PR DESCRIPTION
This PR supports returning CSV with BFF format responses to both the` /submitquery `and `/search` endpoints.  There is an attribute `return_bff` that should be set to `true` to achieve this behaviour. The response header contains information about the pagination (`pagination `attribute) in case the query does not return the results in one call. 

It has been deployed into the `idr-testing `
cc @will-moore 
